### PR TITLE
Provide flags for client id and secret in login command

### DIFF
--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -47,7 +47,10 @@ type Cmd struct {
 	user              string
 	password          string
 	sslDisabled       bool
-	authBuilder       authenticationBuilder
+	clientID          string
+	clientSecret      string
+
+	authBuilder authenticationBuilder
 }
 
 type authenticationBuilder func(*auth.Options) (auth.AuthenticationStrategy, *auth.Options, error)
@@ -72,6 +75,8 @@ func (lc *Cmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 	result.Flags().StringVarP(&lc.serviceManagerURL, "url", "a", "", "Base URL of the Service Manager")
 	result.Flags().StringVarP(&lc.user, "user", "u", "", "User ID")
 	result.Flags().StringVarP(&lc.password, "password", "p", "", "Password")
+	result.Flags().StringVarP(&lc.clientID, "client-id", "", defaultClientID, "Client id used for OAuth flow")
+	result.Flags().StringVarP(&lc.clientSecret, "client-secret", "", defaultClientSecret, "Client secret used for OAuth flow")
 	result.Flags().BoolVarP(&lc.sslDisabled, "skip-ssl-validation", "", false, "Skip verification of the OAuth endpoint. Not recommended!")
 
 	return result
@@ -123,8 +128,8 @@ func (lc *Cmd) Run() error {
 	}
 
 	options := &auth.Options{
-		ClientID:     defaultClientID,
-		ClientSecret: defaultClientSecret,
+		ClientID:     lc.clientID,
+		ClientSecret: lc.clientSecret,
 		IssuerURL:    info.TokenIssuerURL,
 		SSLDisabled:  lc.sslDisabled,
 	}
@@ -143,8 +148,8 @@ func (lc *Cmd) Run() error {
 		SSLDisabled: lc.sslDisabled,
 
 		Token:        *token,
-		ClientID:     defaultClientID,
-		ClientSecret: defaultClientSecret,
+		ClientID:     options.ClientID,
+		ClientSecret: options.ClientSecret,
 
 		IssuerURL:             info.TokenIssuerURL,
 		AuthorizationEndpoint: options.AuthorizationEndpoint,

--- a/internal/cmd/login/login_test.go
+++ b/internal/cmd/login/login_test.go
@@ -62,6 +62,46 @@ var _ = Describe("Login Command test", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(outputBuffer.String()).To(ContainSubstring("Logged in successfully.\n"))
+
+				savedConfig := config.SaveArgsForCall(0)
+				Expect(savedConfig.ClientID).To(Equal("cf"))
+				Expect(savedConfig.ClientSecret).To(Equal(""))
+			})
+		})
+
+		Context("With password and client id provided through flags", func() {
+			It("should save configuration successfully", func() {
+				lc := command.Prepare(cmd.CommonPrepare)
+				lc.SetArgs([]string{"--url=http://valid-url.com", "--password=password", "--client-id=smctl"})
+
+				credentialsBuffer.WriteString("user\n")
+
+				err := lc.Execute()
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(outputBuffer.String()).To(ContainSubstring("Logged in successfully.\n"))
+
+				savedConfig := config.SaveArgsForCall(0)
+				Expect(savedConfig.ClientID).To(Equal("smctl"))
+				Expect(savedConfig.ClientSecret).To(Equal(""))
+			})
+		})
+
+		Context("With password, client id and client secret provided through flags", func() {
+			It("should save configuration successfully", func() {
+				lc := command.Prepare(cmd.CommonPrepare)
+				lc.SetArgs([]string{"--url=http://valid-url.com", "--password=password", "--client-id=smctl", "--client-secret=smctl"})
+
+				credentialsBuffer.WriteString("user\n")
+
+				err := lc.Execute()
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(outputBuffer.String()).To(ContainSubstring("Logged in successfully.\n"))
+
+				savedConfig := config.SaveArgsForCall(0)
+				Expect(savedConfig.ClientID).To(Equal("smctl"))
+				Expect(savedConfig.ClientSecret).To(Equal("smctl"))
 			})
 		})
 

--- a/pkg/auth/strategy.go
+++ b/pkg/auth/strategy.go
@@ -59,5 +59,4 @@ type Refresher interface {
 //go:generate counterfeiter . Client
 type Client interface {
 	Do(*http.Request) (*http.Response, error)
-	// Token() (*Token, error)
 }


### PR DESCRIPTION
## Prerequisites
* Client id and secret cannot be set during login with smctl.

## Motivation
* Users of smctl should be able to provide client id and secret when authenticating against Service Manager

## Approach
Login command flags provided for this purpose

- [x] Initial implementation
- [x ] Unit tests