### PR TITLE
Add option to pass client credentials in request body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.dll
 *.so
 *.dylib
-
+/service-manager-cli
 /out
 
 # Test binary, build with `go test -c`

--- a/internal/cmd/commander.go
+++ b/internal/cmd/commander.go
@@ -87,7 +87,7 @@ func SmPrepare(cmd Command, ctx *Context) func(*cobra.Command, []string) error {
 				ClientSecret:          settings.ClientSecret,
 				IssuerURL:             settings.IssuerURL,
 				SSLDisabled:           settings.SSLDisabled,
-				UseBasicAuth:          settings.TokenBasicAuth,
+				TokenBasicAuth:        settings.TokenBasicAuth,
 			}, &settings.Token)
 
 			refresher, isRefresher := oidcClient.(auth.Refresher)

--- a/internal/cmd/commander.go
+++ b/internal/cmd/commander.go
@@ -87,6 +87,7 @@ func SmPrepare(cmd Command, ctx *Context) func(*cobra.Command, []string) error {
 				ClientSecret:          settings.ClientSecret,
 				IssuerURL:             settings.IssuerURL,
 				SSLDisabled:           settings.SSLDisabled,
+				UseBasicAuth:          settings.TokenBasicAuth,
 			}, &settings.Token)
 
 			refresher, isRefresher := oidcClient.(auth.Refresher)

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -152,6 +152,7 @@ func (lc *Cmd) Run() error {
 		ClientID:     lc.clientID,
 		ClientSecret: lc.clientSecret,
 		IssuerURL:    info.TokenIssuerURL,
+		UseBasicAuth: info.TokenBasicAuth,
 		SSLDisabled:  lc.sslDisabled,
 	}
 
@@ -176,6 +177,7 @@ func (lc *Cmd) Run() error {
 		IssuerURL:             info.TokenIssuerURL,
 		AuthorizationEndpoint: options.AuthorizationEndpoint,
 		TokenEndpoint:         options.TokenEndpoint,
+		TokenBasicAuth:        info.TokenBasicAuth,
 	}
 	if settings.User == "" {
 		settings.User = options.ClientID

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -147,13 +147,13 @@ func (lc *Cmd) Run() error {
 	}
 
 	options := &auth.Options{
-		User:         lc.user,
-		Password:     lc.password,
-		ClientID:     lc.clientID,
-		ClientSecret: lc.clientSecret,
-		IssuerURL:    info.TokenIssuerURL,
-		UseBasicAuth: info.TokenBasicAuth,
-		SSLDisabled:  lc.sslDisabled,
+		User:           lc.user,
+		Password:       lc.password,
+		ClientID:       lc.clientID,
+		ClientSecret:   lc.clientSecret,
+		IssuerURL:      info.TokenIssuerURL,
+		TokenBasicAuth: info.TokenBasicAuth,
+		SSLDisabled:    lc.sslDisabled,
 	}
 
 	authStrategy, options, err := lc.authBuilder(options)

--- a/internal/cmd/login/login_test.go
+++ b/internal/cmd/login/login_test.go
@@ -1,9 +1,12 @@
 package login
 
 import (
+	"fmt"
+
 	"github.com/Peripli/service-manager-cli/pkg/auth"
 	"github.com/Peripli/service-manager-cli/pkg/auth/authfakes"
 	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/spf13/cobra"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,8 +32,11 @@ var _ = Describe("Login Command test", func() {
 	var config configurationfakes.FakeConfiguration
 	var authStrategy *authfakes.FakeAuthenticator
 	var client *smclientfakes.FakeClient
+	var lc *cobra.Command
+	var authOptions auth.Options
 
 	authBuilder := func(options *auth.Options) (auth.Authenticator, *auth.Options, error) {
+		authOptions = *options
 		return authStrategy, options, nil
 	}
 
@@ -51,12 +57,12 @@ var _ = Describe("Login Command test", func() {
 
 		context := &cmd.Context{Output: outputBuffer, Configuration: &config, Client: client}
 		command = NewLoginCmd(context, credentialsBuffer, authBuilder)
+		lc = command.Prepare(cmd.CommonPrepare)
 	})
 
 	Describe("Valid request", func() {
 		Context("With password provided through flag", func() {
 			It("should save configuration successfully", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=http://valid-url.com", "--password=password"})
 
 				credentialsBuffer.WriteString("user\n")
@@ -74,7 +80,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With password and client id provided through flags", func() {
 			It("should save configuration successfully", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=http://valid-url.com", "--password=password", "--client-id=smctl"})
 
 				credentialsBuffer.WriteString("user\n")
@@ -92,7 +97,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With password, client id and client secret provided through flags", func() {
 			It("should save configuration successfully", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=http://valid-url.com", "--password=password", "--client-id=smctl", "--client-secret=smctl"})
 
 				credentialsBuffer.WriteString("user\n")
@@ -110,7 +114,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With user and password provided through flag", func() {
 			It("should save configuration successfully", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=http://valid-url.com", "--user=user", "--password=password"})
 
 				err := lc.Execute()
@@ -122,7 +125,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With verbose flag provided", func() {
 			It("should print more detailed messages", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=http://valid-url.com", "--user=user", "--password=password"})
 
 				err := lc.Execute()
@@ -135,7 +137,6 @@ var _ = Describe("Login Command test", func() {
 		Context("With client credentials flow", func() {
 			When("client id secret are provided through flag", func() {
 				It("login successfully", func() {
-					lc := command.Prepare(cmd.CommonPrepare)
 					lc.SetArgs([]string{"--url=http://valid-url.com", "--auth-flow=client-credentials", "--client-id=id", "--client-secret=secret"})
 
 					err := lc.Execute()
@@ -145,12 +146,32 @@ var _ = Describe("Login Command test", func() {
 				})
 			})
 		})
+
+		Context("Use token_basic_auth returned by info endpoint", func() {
+			for _, tokenBasicAuth := range []bool{true, false} {
+				tokenBasicAuth := tokenBasicAuth
+				It(fmt.Sprintf("token_basic_auth: %v", tokenBasicAuth), func() {
+					client.GetInfoReturns(&types.Info{
+						TokenIssuerURL: "http://valid-uaa.com",
+						TokenBasicAuth: tokenBasicAuth,
+					},
+						nil)
+					lc.SetArgs([]string{"--url=http://valid-url.com", "--user=user", "--password=password"})
+
+					err := lc.Execute()
+
+					Expect(err).ShouldNot(HaveOccurred())
+					savedConfig := config.SaveArgsForCall(0)
+					Expect(authOptions.UseBasicAuth).To(Equal(tokenBasicAuth))
+					Expect(savedConfig.TokenBasicAuth).To(Equal(tokenBasicAuth))
+				})
+			}
+		})
 	})
 
 	Describe("Invalid request", func() {
 		Context("With no URL flag provided", func() {
 			It("should return error", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				err := lc.Execute()
 
 				Expect(err).Should(HaveOccurred())
@@ -160,7 +181,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With invalid URL flag provided", func() {
 			It("should return error", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=htp://invalid-url.com"})
 				err := lc.Execute()
 
@@ -171,7 +191,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With empty username provided", func() {
 			It("should return error", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=http://valid-url.com", "--password=password"})
 				credentialsBuffer.WriteString("\n")
 				err := lc.Execute()
@@ -182,7 +201,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With error while typing user in", func() {
 			It("should save configuration successfully", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 
 				err := lc.Execute()
 
@@ -192,7 +210,6 @@ var _ = Describe("Login Command test", func() {
 
 		Context("With error while saving configuration", func() {
 			It("should return error", func() {
-				lc := command.Prepare(cmd.CommonPrepare)
 				lc.SetArgs([]string{"--url=http://valid-url.com", "--user=user", "--password=password"})
 				config.SaveReturns(errors.New("saving configuration error"))
 
@@ -206,7 +223,6 @@ var _ = Describe("Login Command test", func() {
 		Context("With client-credentials flow", func() {
 			When("client id and secret is not provided", func() {
 				It("should return an error", func() {
-					lc := command.Prepare(cmd.CommonPrepare)
 					lc.SetArgs([]string{"--url=http://valid-url.com", "--auth-flow=client-credentials"})
 
 					err := lc.Execute()
@@ -218,7 +234,6 @@ var _ = Describe("Login Command test", func() {
 
 			When("client id is not provided", func() {
 				It("should return an error", func() {
-					lc := command.Prepare(cmd.CommonPrepare)
 					lc.SetArgs([]string{"--url=http://valid-url.com", "--auth-flow=client-credentials", "--client-secret", "secret"})
 
 					err := lc.Execute()

--- a/internal/cmd/login/login_test.go
+++ b/internal/cmd/login/login_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Login Command test", func() {
 
 					Expect(err).ShouldNot(HaveOccurred())
 					savedConfig := config.SaveArgsForCall(0)
-					Expect(authOptions.UseBasicAuth).To(Equal(tokenBasicAuth))
+					Expect(authOptions.TokenBasicAuth).To(Equal(tokenBasicAuth))
 					Expect(savedConfig.TokenBasicAuth).To(Equal(tokenBasicAuth))
 				})
 			}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -29,16 +29,16 @@ import (
 type Settings struct {
 	auth.Token
 
-	TokenBasicAuth        bool
 	ClientID              string
 	ClientSecret          string
 	AuthorizationEndpoint string
 	TokenEndpoint         string
 	IssuerURL             string
 
-	URL         string
-	User        string
-	SSLDisabled bool
+	URL            string
+	User           string
+	TokenBasicAuth bool
+	SSLDisabled    bool
 }
 
 // Validate validates client config

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -29,6 +29,7 @@ import (
 type Settings struct {
 	auth.Token
 
+	TokenBasicAuth        bool
 	ClientID              string
 	ClientSecret          string
 	AuthorizationEndpoint string
@@ -84,6 +85,7 @@ func NewSMConfiguration(viperEnv *viper.Viper, cfgFile string) (Configuration, e
 	}
 
 	viperEnv.SetConfigFile(cfgFile)
+	viperEnv.SetDefault("token_basic_auth", true) // RFC 6749 section 2.3.1
 
 	return &smConfiguration{viperEnv}, nil
 }
@@ -93,6 +95,7 @@ func (smCfg *smConfiguration) Save(settings *Settings) error {
 	smCfg.viperEnv.Set("url", settings.URL)
 	smCfg.viperEnv.Set("user", settings.User)
 	smCfg.viperEnv.Set("ssl_disabled", settings.SSLDisabled)
+	smCfg.viperEnv.Set("token_basic_auth", settings.TokenBasicAuth)
 
 	smCfg.viperEnv.Set("access_token", settings.AccessToken)
 	smCfg.viperEnv.Set("refresh_token", settings.RefreshToken)
@@ -120,6 +123,7 @@ func (smCfg *smConfiguration) Load() (*Settings, error) {
 	}
 
 	settings.SSLDisabled = smCfg.viperEnv.Get("ssl_disabled").(bool)
+	settings.TokenBasicAuth = smCfg.viperEnv.Get("token_basic_auth").(bool)
 	settings.AccessToken = smCfg.viperEnv.Get("access_token").(string)
 	settings.RefreshToken = smCfg.viperEnv.Get("refresh_token").(string)
 	settings.ExpiresIn, _ = time.Parse(time.RFC1123Z, smCfg.viperEnv.Get("expiry").(string))

--- a/pkg/auth/oidc/common.go
+++ b/pkg/auth/oidc/common.go
@@ -33,6 +33,10 @@ import (
 // If token is provided will try to refresh the token if it has expired,
 // otherwise if token is not provided will do client_credentials flow and fetch token
 func NewClient(options *auth.Options, token *auth.Token) auth.Client {
+	if !options.UseBasicAuth {
+		oauth2.RegisterBrokenAuthHeaderProvider(options.IssuerURL)
+	}
+
 	httpClient := util.BuildHTTPClient(options.SSLDisabled)
 	httpClient.Timeout = options.Timeout
 

--- a/pkg/auth/oidc/common.go
+++ b/pkg/auth/oidc/common.go
@@ -33,7 +33,7 @@ import (
 // If token is provided will try to refresh the token if it has expired,
 // otherwise if token is not provided will do client_credentials flow and fetch token
 func NewClient(options *auth.Options, token *auth.Token) auth.Client {
-	if !options.UseBasicAuth {
+	if !options.TokenBasicAuth {
 		oauth2.RegisterBrokenAuthHeaderProvider(options.IssuerURL)
 	}
 

--- a/pkg/auth/oidc/oidc.go
+++ b/pkg/auth/oidc/oidc.go
@@ -44,7 +44,7 @@ type OpenIDStrategy struct {
 
 // NewOpenIDStrategy returns OpenId auth strategy
 func NewOpenIDStrategy(options *auth.Options) (*OpenIDStrategy, *auth.Options, error) {
-	if !options.UseBasicAuth {
+	if !options.TokenBasicAuth {
 		oauth2.RegisterBrokenAuthHeaderProvider(options.IssuerURL)
 	}
 

--- a/pkg/auth/oidc/oidc.go
+++ b/pkg/auth/oidc/oidc.go
@@ -44,6 +44,10 @@ type OpenIDStrategy struct {
 
 // NewOpenIDStrategy returns OpenId auth strategy
 func NewOpenIDStrategy(options *auth.Options) (*OpenIDStrategy, *auth.Options, error) {
+	if !options.UseBasicAuth {
+		oauth2.RegisterBrokenAuthHeaderProvider(options.IssuerURL)
+	}
+
 	httpClient := util.BuildHTTPClient(options.SSLDisabled)
 	httpClient.Timeout = options.Timeout
 

--- a/pkg/auth/strategy.go
+++ b/pkg/auth/strategy.go
@@ -31,8 +31,8 @@ type Options struct {
 	TokenEndpoint         string `mapstructure:"token_endpoint"`
 	IssuerURL             string `mapstructure:"issuer_url"`
 
-	UseBasicAuth bool `mapstructure:"use_basic_auth"`
-	SSLDisabled  bool `mapstructure:"ssl_disabled"`
+	TokenBasicAuth bool `mapstructure:"token_basic_auth"`
+	SSLDisabled    bool `mapstructure:"ssl_disabled"`
 
 	Timeout time.Duration `mapstructure:"timeout"`
 }

--- a/pkg/auth/strategy.go
+++ b/pkg/auth/strategy.go
@@ -31,7 +31,8 @@ type Options struct {
 	TokenEndpoint         string `mapstructure:"token_endpoint"`
 	IssuerURL             string `mapstructure:"issuer_url"`
 
-	SSLDisabled bool `mapstructure:"ssl_disabled"`
+	UseBasicAuth bool `mapstructure:"use_basic_auth"`
+	SSLDisabled  bool `mapstructure:"ssl_disabled"`
 
 	Timeout time.Duration `mapstructure:"timeout"`
 }

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -102,14 +102,13 @@ func (client *serviceManagerClient) GetInfo() (*types.Info, error) {
 		return nil, errors.ResponseError{StatusCode: response.StatusCode}
 	}
 
-	var result *types.Info
-
-	err = httputil.UnmarshalResponse(response, &result)
+	info := types.DefaultInfo
+	err = httputil.UnmarshalResponse(response, &info)
 	if err != nil {
 		return nil, err
 	}
 
-	return result, nil
+	return &info, nil
 }
 
 // RegisterPlatform registers a platform in the service manager

--- a/pkg/smclient/client_test.go
+++ b/pkg/smclient/client_test.go
@@ -437,12 +437,24 @@ var _ = Describe("Service Manager Client test", func() {
 
 	Describe("Get info", func() {
 		Context("when token issuer is set", func() {
-			It("should get the right issuer", func() {
+			It("should get the right issuer and default token basic auth", func() {
 				responseStatusCode = http.StatusOK
 				responseBody = []byte(`{"token_issuer_url": "http://uaa.com"}`)
 
 				info, _ := client.GetInfo()
 				Expect(info.TokenIssuerURL).To(Equal("http://uaa.com"))
+				Expect(info.TokenBasicAuth).To(BeTrue()) // default value
+			})
+		})
+
+		Context("when token basic auth is set", func() {
+			It("should get the right value", func() {
+				responseStatusCode = http.StatusOK
+				responseBody = []byte(`{"token_issuer_url": "http://uaa.com", "token_basic_auth": false}`)
+
+				info, _ := client.GetInfo()
+				Expect(info.TokenIssuerURL).To(Equal("http://uaa.com"))
+				Expect(info.TokenBasicAuth).To(BeFalse())
 			})
 		})
 

--- a/pkg/types/info.go
+++ b/pkg/types/info.go
@@ -19,4 +19,10 @@ package types
 // Info contains the url of a token issuer
 type Info struct {
 	TokenIssuerURL string `json:"token_issuer_url"`
+	TokenBasicAuth bool   `json:"token_basic_auth"`
+}
+
+// DefaultInfo contains default values
+var DefaultInfo = Info{
+	TokenBasicAuth: true, // RFC 6749 section 2.3.1
 }


### PR DESCRIPTION
Some authorization servers like CF UAA have issues when client credentials are passed as basic auth.
See https://github.com/cloudfoundry/uaa/issues/778

SM can return on the info endpoint a new property token_basic_auth (default true).
If token_basic_auth is false, client credentials are sent in the body instead of in authorization header (basic auth).