### PR TITLE
Update Brokers struct tag

### DIFF
--- a/pkg/types/broker.go
+++ b/pkg/types/broker.go
@@ -52,7 +52,7 @@ func (b *Broker) TableData() *TableData {
 
 // Brokers wraps an array of brokers
 type Brokers struct {
-	Brokers []Broker `json:"brokers"`
+	Brokers []Broker `json:"service_brokers"`
 }
 
 // IsEmpty whether the structure is empty


### PR DESCRIPTION
# Update Brokers struct tag

## Motivation
This pull request https://github.com/Peripli/service-manager/pull/223 introduces a breaking change. The CLI needs to be adapted so that `list-brokers` command behaves properly.

## Approach
The `types.Brokers` struct's tag is update with accordance to the response body of the `/v1/service_brokers` endpoint.
