### PR TITLE
Fix oidc

### DIFF
--- a/pkg/auth/oidc/common.go
+++ b/pkg/auth/oidc/common.go
@@ -54,25 +54,9 @@ func NewClient(options *auth.Options, token *auth.Token) auth.Client {
 	}
 
 	if token == nil || tt.RefreshToken == "" {
-		oauthConfig := &clientcredentials.Config{
-			ClientID:     options.ClientID,
-			ClientSecret: options.ClientSecret,
-			TokenURL:     options.TokenEndpoint,
-		}
-		clientCredentialsSource := oauthConfig.TokenSource(ctx)
-		// The double wrapping of TokenSource objects is needed, because there is no other way
-		// to pass the existing access token and the client will try to fetch a token for each request
-		tokenSource = oauth2.ReuseTokenSource(&tt, clientCredentialsSource)
+		tokenSource = clientCredentialsTokenSource(ctx, options, tt)
 	} else {
-		oauthConfig := &oauth2.Config{
-			ClientID:     options.ClientID,
-			ClientSecret: options.ClientSecret,
-			Endpoint: oauth2.Endpoint{
-				AuthURL:  options.AuthorizationEndpoint,
-				TokenURL: options.TokenEndpoint,
-			},
-		}
-		tokenSource = oauthConfig.TokenSource(ctx, &tt)
+		tokenSource = refreshTokenSource(ctx, options, tt)
 	}
 
 	oauthClient = oauth2.NewClient(ctx, tokenSource)
@@ -82,6 +66,30 @@ func NewClient(options *auth.Options, token *auth.Token) auth.Client {
 		tokenSource: tokenSource,
 		httpClient:  oauthClient,
 	}
+}
+
+func refreshTokenSource(ctx context.Context, options *auth.Options, token oauth2.Token) oauth2.TokenSource {
+	oauthConfig := &oauth2.Config{
+		ClientID:     options.ClientID,
+		ClientSecret: options.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  options.AuthorizationEndpoint,
+			TokenURL: options.TokenEndpoint,
+		},
+	}
+	return oauthConfig.TokenSource(ctx, &token)
+}
+
+func clientCredentialsTokenSource(ctx context.Context, options *auth.Options, token oauth2.Token) oauth2.TokenSource {
+	oauthConfig := &clientcredentials.Config{
+		ClientID:     options.ClientID,
+		ClientSecret: options.ClientSecret,
+		TokenURL:     options.TokenEndpoint,
+	}
+	clientCredentialsSource := oauthConfig.TokenSource(ctx)
+	// The double wrapping of TokenSource objects is needed, because there is no other way
+	// to pass the existing access token and the client will try to fetch a token for each request
+	return oauth2.ReuseTokenSource(&token, clientCredentialsSource)
 }
 
 // Client is used to make http requests including bearer token automatically and refreshing it


### PR DESCRIPTION
# Pull Request Template

Fixes bug which appears in Service Manager during runtime, because CLI is used as dependency to construct OIDC client. It crashes because the token in nil, but the code is trying to reference it.

#### Pull Request status
Use checklists as a means to represent the status of your Pull Request.

- [x] Initial implementation
- [x] Refactoring
- [ ] Unit tests

[1]: https://github.com/Peripli/service-manager/blob/master/CONTRIBUTING.md