### PR TITLE
Add commands for listing service offerings and plans.

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  version = "0.1.8"
+  version = "0.1.12"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/internal/cmd/broker/list_brokers_test.go
+++ b/internal/cmd/broker/list_brokers_test.go
@@ -123,11 +123,12 @@ var _ = Describe("List brokers command test", func() {
 
 	Context("when error is returned by Service manager", func() {
 		It("should handle error", func() {
-			client.ListBrokersReturns(nil, errors.New("Http Client Error"))
+			expectedErr :=  errors.New("Http Client Error")
+			client.ListBrokersReturns(nil, expectedErr)
 			err := executeWithArgs([]string{})
 
 			Expect(err).Should(HaveOccurred())
-			Expect(err).To(MatchError("Http Client Error"))
+			Expect(err).To(MatchError(expectedErr))
 		})
 	})
 

--- a/internal/cmd/curl/curl_test.go
+++ b/internal/cmd/curl/curl_test.go
@@ -3,6 +3,7 @@ package curl
 import (
 	"encoding/json"
 	"errors"
+	"github.com/Peripli/service-manager/pkg/web"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -82,7 +83,7 @@ var _ = Describe("Curl command test", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			setCallReturns(200, expectedOutput, nil)
-			err = executeWithArgs([]string{"/v1/service_brokers"})
+			err = executeWithArgs([]string{web.BrokersURL})
 			Expect(err).To(BeNil())
 			Expect(buffer.String()).To(Equal(string(expectedOutput)))
 		})
@@ -91,7 +92,7 @@ var _ = Describe("Curl command test", func() {
 	Context("when curl with path, method and body", func() {
 		It("should do GET method", func() {
 			setCallReturns(200, nil, nil)
-			assertLastCall(http.MethodGet, "/v1/service_brokers", nil, "", nil)
+			assertLastCall(http.MethodGet, web.BrokersURL, nil, "", nil)
 		})
 
 		It("should do PATCH method", func() {
@@ -101,7 +102,7 @@ var _ = Describe("Curl command test", func() {
 			body, err := json.MarshalIndent(&broker, "", "  ")
 			Expect(err).ShouldNot(HaveOccurred())
 			setCallReturns(201, body, nil)
-			assertLastCall(http.MethodPost, "/v1/service_brokers", body, string(body), nil)
+			assertLastCall(http.MethodPost, web.BrokersURL, body, string(body), nil)
 		})
 
 		Context("when body is file", func() {
@@ -119,7 +120,7 @@ var _ = Describe("Curl command test", func() {
 				f.Write([]byte(content))
 
 				setCallReturns(201, []byte(content), nil)
-				assertLastCall(http.MethodPost, "/v1/service_brokers", []byte(`@test.txt`), string(content), nil)
+				assertLastCall(http.MethodPost, web.BrokersURL, []byte(`@test.txt`), string(content), nil)
 			})
 		})
 	})
@@ -128,7 +129,7 @@ var _ = Describe("Curl command test", func() {
 		It("should handle error", func() {
 			err := errors.New("problem during call")
 			setCallReturns(0, nil, err)
-			assertLastCall(http.MethodGet, "/v1/service_brokers", nil, "", err)
+			assertLastCall(http.MethodGet, web.BrokersURL, nil, "", err)
 		})
 	})
 })

--- a/internal/cmd/offering/list_offerings.go
+++ b/internal/cmd/offering/list_offerings.go
@@ -50,7 +50,7 @@ func (lo *ListOfferingsCmd) Run() error {
 		plans := &types.ServicePlans{}
 		for _, v := range offerings.ServiceOfferings {
 			if v.Name == lo.offering {
-				plans.ServicePlans = v.Plans
+				plans.ServicePlans = append(plans.ServicePlans, v.Plans...)
 			}
 		}
 		output.PrintServiceManagerObject(lo.Output, lo.outputFormat, plans)

--- a/internal/cmd/offering/list_offerings.go
+++ b/internal/cmd/offering/list_offerings.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package offering
+
+import (
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// ListOfferingsCmd wraps the smctl list-offerings command
+type ListOfferingsCmd struct {
+	*cmd.Context
+
+	prepare      cmd.PrepareFunc
+	outputFormat output.Format
+
+	offering string
+}
+
+// NewListOfferingsCmd returns new list-offerings command with context
+func NewListOfferingsCmd(context *cmd.Context) *ListOfferingsCmd {
+	return &ListOfferingsCmd{Context: context}
+}
+
+// Run runs the command's logic
+func (lo *ListOfferingsCmd) Run() error {
+	offerings, err := lo.Client.ListOfferings()
+	if err != nil {
+		return err
+	}
+	if lo.offering == "" {
+		output.PrintServiceManagerObject(lo.Output, lo.outputFormat, offerings)
+	} else {
+		plans := &types.ServicePlans{}
+		for _, v := range offerings.ServiceOfferings {
+			if v.Name == lo.offering {
+				plans.ServicePlans = v.Plans
+			}
+		}
+		output.PrintServiceManagerObject(lo.Output, lo.outputFormat, plans)
+	}
+	output.Println(lo.Output)
+	return nil
+}
+
+// SetOutputFormat set output format
+func (lo *ListOfferingsCmd) SetOutputFormat(format output.Format) {
+	lo.outputFormat = format
+}
+
+// HideUsage hide command's usage
+func (lo *ListOfferingsCmd) HideUsage() bool {
+	return true
+}
+
+// Prepare returns cobra command
+func (lo *ListOfferingsCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	lo.prepare = prepare
+	result := &cobra.Command{
+		Use:     "list-offerings",
+		Aliases: []string{"lo"},
+		Short:   "List service offerings",
+		Long:    `List all service offerings.`,
+		PreRunE: lo.prepare(lo, lo.Context),
+		RunE:    cmd.RunE(lo),
+	}
+
+	cmd.AddFormatFlag(result.Flags())
+	result.Flags().StringVarP(&lo.offering, "service", "s", "", "Plan details for a single service offering")
+
+	return result
+}

--- a/internal/cmd/offering/list_offerings_test.go
+++ b/internal/cmd/offering/list_offerings_test.go
@@ -25,17 +25,17 @@ var _ = Describe("List offerings command test", func() {
 	var buffer *bytes.Buffer
 
 	plan1 := types.ServicePlan{
-		Name: "plan 1",
+		Name: "plan1",
 		Description: "desc",
 	}
 
 	plan2 := types.ServicePlan{
-		Name: "plan 2",
+		Name: "plan2",
 		Description: "desc",
 	}
 
 	noPlanOffering := types.ServiceOffering{
-		Name: "no plan offering",
+		Name: "no-plan-offering",
 		Plans: []types.ServicePlan{},
 		Description: "desc",
 		BrokerName: "broker",
@@ -43,18 +43,18 @@ var _ = Describe("List offerings command test", func() {
 	}
 
 	offering1 := types.ServiceOffering{
-		Name: "offering 1",
+		Name: "offering1",
 		Plans: []types.ServicePlan{plan1},
 		Description: "desc",
-		BrokerName: "broker 1",
+		BrokerName: "broker1",
 		BrokerID: "id1",
 	}
 
 	offering2 := types.ServiceOffering{
-		Name: "offering 2",
+		Name: "offering2",
 		Plans: []types.ServicePlan{plan1, plan2},
 		Description: "desc",
-		BrokerName: "broker 2",
+		BrokerName: "broker2",
 		BrokerID: "id2",
 	}
 
@@ -107,7 +107,7 @@ var _ = Describe("List offerings command test", func() {
 		It("should list empty plans list when no plans provided", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{noPlanOffering}}
 			client.ListOfferingsReturns(result, nil)
-			err := executeWithArgs([]string{"-s", "no plan offering"})
+			err := executeWithArgs([]string{"-s", "no-plan-offering"})
 
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring("There are no service plans for this service offering."))
@@ -116,7 +116,7 @@ var _ = Describe("List offerings command test", func() {
 		It("should list 1 plan when a single plan is provided", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
 			client.ListOfferingsReturns(result, nil)
-			err := executeWithArgs([]string{"-s", "offering 1"})
+			err := executeWithArgs([]string{"-s", "offering1"})
 
 			expected := &types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans}
 
@@ -127,11 +127,12 @@ var _ = Describe("List offerings command test", func() {
 		It("should list multiple plans when multiple plans are provided", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering2}}
 			client.ListOfferingsReturns(result, nil)
-			err := executeWithArgs([]string{"-s", "offering 2"})
+			err := executeWithArgs([]string{"-s", "offering2"})
 
 			expected := &types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans}
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(expected.Message()))
 			Expect(buffer.String()).To(ContainSubstring(expected.TableData().String()))
 		})
 	})
@@ -163,7 +164,7 @@ var _ = Describe("List offerings command test", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
 			client.ListOfferingsReturns(result, nil)
 
-			executeWithArgs([]string{"-s", "offering 1", "-o", "json"})
+			executeWithArgs([]string{"-s", "offering1", "-o", "json"})
 
 			jsonByte, _ := json.MarshalIndent(&types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans}, "", "  ")
 			jsonOutputExpected := string(jsonByte) + "\n"
@@ -174,7 +175,7 @@ var _ = Describe("List offerings command test", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
 			client.ListOfferingsReturns(result, nil)
 
-			executeWithArgs([]string{"-s", "offering 1", "-o", "yaml"})
+			executeWithArgs([]string{"-s", "offering1", "-o", "yaml"})
 
 			yamlByte, _ := yaml.Marshal(&types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans})
 			yamlOutputExpected := string(yamlByte) + "\n"
@@ -201,11 +202,12 @@ var _ = Describe("List offerings command test", func() {
 
 	Context("when error is returned by Service manager", func() {
 		It("should handle error", func() {
-			client.ListOfferingsReturns(nil, errors.New("Http Client Error"))
+			expectedErr := errors.New("Http Client Error")
+			client.ListOfferingsReturns(nil, expectedErr)
 			err := executeWithArgs([]string{})
 
 			Expect(err).Should(HaveOccurred())
-			Expect(err).To(MatchError("Http Client Error"))
+			Expect(err).To(MatchError(expectedErr))
 		})
 	})
 

--- a/internal/cmd/offering/list_offerings_test.go
+++ b/internal/cmd/offering/list_offerings_test.go
@@ -1,0 +1,212 @@
+package offering
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestListOfferingsCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("List offerings command test", func() {
+
+	var client *smclientfakes.FakeClient
+	var command *ListOfferingsCmd
+	var buffer *bytes.Buffer
+
+	plan1 := types.ServicePlan{
+		Name: "plan 1",
+		Description: "desc",
+	}
+
+	plan2 := types.ServicePlan{
+		Name: "plan 2",
+		Description: "desc",
+	}
+
+	noPlanOffering := types.ServiceOffering{
+		Name: "no plan offering",
+		Plans: []types.ServicePlan{},
+		Description: "desc",
+		BrokerName: "broker",
+		BrokerID: "id",
+	}
+
+	offering1 := types.ServiceOffering{
+		Name: "offering 1",
+		Plans: []types.ServicePlan{plan1},
+		Description: "desc",
+		BrokerName: "broker 1",
+		BrokerID: "id1",
+	}
+
+	offering2 := types.ServiceOffering{
+		Name: "offering 2",
+		Plans: []types.ServicePlan{plan1, plan2},
+		Description: "desc",
+		BrokerName: "broker 2",
+		BrokerID: "id2",
+	}
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		client = &smclientfakes.FakeClient{}
+		context := &cmd.Context{Output: buffer, Client: client}
+		command = NewListOfferingsCmd(context)
+	})
+
+	executeWithArgs := func(args []string) error {
+		commandToRun := command.Prepare(cmd.SmPrepare)
+		commandToRun.SetArgs(args)
+
+		return commandToRun.Execute()
+	}
+
+	Context("when no offerings provided", func() {
+		It("should list empty offerings list", func() {
+			client.ListOfferingsReturns(&types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{}}, nil)
+			err := executeWithArgs([]string{})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("There are no service offerings"))
+		})
+	})
+
+	Context("when offerings are provided", func() {
+		It("should list 1 offering", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
+			client.ListOfferingsReturns(result, nil)
+			err := executeWithArgs([]string{})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(result.TableData().String()))
+		})
+
+		It("should list more offerings", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1, offering2}}
+			client.ListOfferingsReturns(result, nil)
+			err := executeWithArgs([]string{})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(result.Message()))
+			Expect(buffer.String()).To(ContainSubstring(result.TableData().String()))
+		})
+	})
+
+	Context("when service flag is used", func() {
+		It("should list empty plans list when no plans provided", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{noPlanOffering}}
+			client.ListOfferingsReturns(result, nil)
+			err := executeWithArgs([]string{"-s", "no plan offering"})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("There are no service plans for this service offering."))
+		})
+
+		It("should list 1 plan when a single plan is provided", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
+			client.ListOfferingsReturns(result, nil)
+			err := executeWithArgs([]string{"-s", "offering 1"})
+
+			expected := &types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans}
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(expected.TableData().String()))
+		})
+
+		It("should list multiple plans when multiple plans are provided", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering2}}
+			client.ListOfferingsReturns(result, nil)
+			err := executeWithArgs([]string{"-s", "offering 2"})
+
+			expected := &types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans}
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(expected.TableData().String()))
+		})
+	})
+
+	Context("when format flag is used", func() {
+		It("should print offerings in json", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
+			client.ListOfferingsReturns(result, nil)
+
+			executeWithArgs([]string{"-o", "json"})
+
+			jsonByte, _ := json.MarshalIndent(result, "", "  ")
+			jsonOutputExpected := string(jsonByte) + "\n"
+			Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
+		})
+
+		It("should print offerings in yaml", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
+			client.ListOfferingsReturns(result, nil)
+
+			executeWithArgs([]string{"-o", "yaml"})
+
+			yamlByte, _ := yaml.Marshal(result)
+			yamlOutputExpected := string(yamlByte) + "\n"
+			Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
+		})
+
+		It("should print plans in json", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
+			client.ListOfferingsReturns(result, nil)
+
+			executeWithArgs([]string{"-s", "offering 1", "-o", "json"})
+
+			jsonByte, _ := json.MarshalIndent(&types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans}, "", "  ")
+			jsonOutputExpected := string(jsonByte) + "\n"
+			Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
+		})
+
+		It("should print plans in yaml", func() {
+			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
+			client.ListOfferingsReturns(result, nil)
+
+			executeWithArgs([]string{"-s", "offering 1", "-o", "yaml"})
+
+			yamlByte, _ := yaml.Marshal(&types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans})
+			yamlOutputExpected := string(yamlByte) + "\n"
+			Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
+		})
+
+
+	})
+
+	Context("when invalid flag is used", func() {
+		It("should handle cobra error", func() {
+			err := executeWithArgs([]string{"--ooutput", "json"})
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("unknown flag: --ooutput"))
+		})
+
+		It("should handle wrong value", func() {
+			err := executeWithArgs([]string{"--output", "invalid"})
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("unknown output: invalid"))
+		})
+	})
+
+	Context("when error is returned by Service manager", func() {
+		It("should handle error", func() {
+			client.ListOfferingsReturns(nil, errors.New("Http Client Error"))
+			err := executeWithArgs([]string{})
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("Http Client Error"))
+		})
+	})
+
+})

--- a/internal/cmd/platform/list_platforms_test.go
+++ b/internal/cmd/platform/list_platforms_test.go
@@ -123,11 +123,12 @@ var _ = Describe("List platforms command test", func() {
 
 	Context("when error is returned by Service manager", func() {
 		It("should handle error", func() {
-			client.ListPlatformsReturns(nil, errors.New("Http Client Error"))
+			expectedErr :=  errors.New("Http Client Error")
+			client.ListPlatformsReturns(nil,expectedErr)
 			err := executeWithArgs([]string{})
 
 			Expect(err).Should(HaveOccurred())
-			Expect(err).To(MatchError("Http Client Error"))
+			Expect(err).To(MatchError(expectedErr))
 		})
 	})
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Peripli/service-manager-cli/internal/cmd/curl"
 	"github.com/Peripli/service-manager-cli/internal/cmd/info"
 	"github.com/Peripli/service-manager-cli/internal/cmd/login"
+	"github.com/Peripli/service-manager-cli/internal/cmd/offering"
 	"github.com/Peripli/service-manager-cli/internal/cmd/platform"
 	"github.com/Peripli/service-manager-cli/internal/cmd/version"
 	"github.com/Peripli/service-manager-cli/pkg/auth"
@@ -63,6 +64,7 @@ func main() {
 			platform.NewListPlatformsCmd(context),
 			platform.NewDeletePlatformCmd(context, os.Stdin),
 			platform.NewUpdatePlatformCmd(context),
+			offering.NewListOfferingsCmd(context),
 		},
 		PrepareFn: cmd.SmPrepare,
 	}

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -185,20 +185,20 @@ func (client *serviceManagerClient) ListOfferings() (*types.ServiceOfferings, er
 	serviceOfferings := &types.ServiceOfferings{}
 	err := client.list(serviceOfferings, "/v1/service_offerings")
 	if err != nil {
-		return serviceOfferings, err
+		return nil, err
 	}
 	for i, v := range serviceOfferings.ServiceOfferings {
 		plans := &types.ServicePlans{}
 		err := client.list(plans, "/v1/service_plans?fieldQuery=service_offering_id+=+"+v.ID)
 		if err != nil {
-			return serviceOfferings, err
+			return nil, err
 		}
 		serviceOfferings.ServiceOfferings[i].Plans = plans.ServicePlans
 
 		broker := &types.Broker{}
 		err = client.list(broker, "/v1/service_brokers/" + v.BrokerID)
 		if err != nil {
-			return serviceOfferings, err
+			return nil, err
 		}
 
 		serviceOfferings.ServiceOfferings[i].BrokerName = broker.Name

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -185,20 +185,20 @@ func (client *serviceManagerClient) ListOfferings() (*types.ServiceOfferings, er
 	serviceOfferings := &types.ServiceOfferings{}
 	err := client.list(serviceOfferings, "/v1/service_offerings")
 	if err != nil {
-		return nil, err
+		return serviceOfferings, err
 	}
 	for i, v := range serviceOfferings.ServiceOfferings {
 		plans := &types.ServicePlans{}
 		err := client.list(plans, "/v1/service_plans?fieldQuery=service_offering_id+=+"+v.ID)
 		if err != nil {
-			return nil, err
+			return serviceOfferings, err
 		}
 		serviceOfferings.ServiceOfferings[i].Plans = plans.ServicePlans
 
 		broker := &types.Broker{}
 		err = client.list(broker, "/v1/service_brokers/" + v.BrokerID)
 		if err != nil {
-			return nil, err
+			return serviceOfferings, err
 		}
 
 		serviceOfferings.ServiceOfferings[i].BrokerName = broker.Name

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -19,6 +19,7 @@ package smclient
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/Peripli/service-manager/pkg/web"
 	"io"
 	"net/http"
 
@@ -94,7 +95,7 @@ func NewClient(httpClient auth.Client, URL string) Client {
 }
 
 func (client *serviceManagerClient) GetInfo() (*types.Info, error) {
-	response, err := client.Call(http.MethodGet, "/v1/info", nil)
+	response, err := client.Call(http.MethodGet, web.InfoURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +121,7 @@ func (client *serviceManagerClient) RegisterPlatform(platform *types.Platform) (
 	}
 
 	buffer := bytes.NewBuffer(requestBody)
-	response, err := client.Call(http.MethodPost, "/v1/platforms", buffer)
+	response, err := client.Call(http.MethodPost, web.PlatformsURL , buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +147,7 @@ func (client *serviceManagerClient) RegisterBroker(broker *types.Broker) (*types
 	}
 
 	buffer := bytes.NewBuffer(requestBody)
-	response, err := client.Call(http.MethodPost, "/v1/service_brokers", buffer)
+	response, err := client.Call(http.MethodPost, web.BrokersURL, buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +168,7 @@ func (client *serviceManagerClient) RegisterBroker(broker *types.Broker) (*types
 // ListBrokers returns brokers registered in the Service Manager
 func (client *serviceManagerClient) ListBrokers() (*types.Brokers, error) {
 	brokers := &types.Brokers{}
-	err := client.list(brokers, "/v1/service_brokers")
+	err := client.list(brokers, web.BrokersURL)
 
 	return brokers, err
 }
@@ -175,7 +176,7 @@ func (client *serviceManagerClient) ListBrokers() (*types.Brokers, error) {
 // ListPlatforms returns platforms registered in the Service Manager
 func (client *serviceManagerClient) ListPlatforms() (*types.Platforms, error) {
 	platforms := &types.Platforms{}
-	err := client.list(platforms, "/v1/platforms")
+	err := client.list(platforms, web.PlatformsURL)
 
 	return platforms, err
 }
@@ -183,20 +184,20 @@ func (client *serviceManagerClient) ListPlatforms() (*types.Platforms, error) {
 // ListOfferings returns service offerings of brokers registered in Service Manager
 func (client *serviceManagerClient) ListOfferings() (*types.ServiceOfferings, error) {
 	serviceOfferings := &types.ServiceOfferings{}
-	err := client.list(serviceOfferings, "/v1/service_offerings")
+	err := client.list(serviceOfferings, web.ServiceOfferingsURL)
 	if err != nil {
 		return nil, err
 	}
 	for i, v := range serviceOfferings.ServiceOfferings {
 		plans := &types.ServicePlans{}
-		err := client.list(plans, "/v1/service_plans?fieldQuery=service_offering_id+=+"+v.ID)
+		err := client.list(plans, web.ServicePlansURL + "?fieldQuery=service_offering_id+=+"+v.ID)
 		if err != nil {
 			return nil, err
 		}
 		serviceOfferings.ServiceOfferings[i].Plans = plans.ServicePlans
 
 		broker := &types.Broker{}
-		err = client.list(broker, "/v1/service_brokers/" + v.BrokerID)
+		err = client.list(broker, web.BrokersURL + "/" + v.BrokerID)
 		if err != nil {
 			return nil, err
 		}
@@ -220,15 +221,15 @@ func (client *serviceManagerClient) list(result interface{}, path string) error 
 }
 
 func (client *serviceManagerClient) DeleteBroker(id string) error {
-	return client.delete(id, "/v1/service_brokers/")
+	return client.delete(id, web.BrokersURL)
 }
 
 func (client *serviceManagerClient) DeletePlatform(id string) error {
-	return client.delete(id, "/v1/platforms/")
+	return client.delete(id, web.PlatformsURL)
 }
 
 func (client *serviceManagerClient) delete(id, path string) error {
-	resp, err := client.Call(http.MethodDelete, path+id, nil)
+	resp, err := client.Call(http.MethodDelete, path + "/" + id, nil)
 	if err != nil {
 		return err
 	}
@@ -247,7 +248,7 @@ func (client *serviceManagerClient) UpdateBroker(id string, updatedBroker *types
 	}
 
 	result := &types.Broker{}
-	return result, client.update(result, requestBody, id, "/v1/service_brokers/")
+	return result, client.update(result, requestBody, id, web.BrokersURL)
 }
 
 func (client *serviceManagerClient) UpdatePlatform(id string, updatedPlatform *types.Platform) (*types.Platform, error) {
@@ -256,12 +257,12 @@ func (client *serviceManagerClient) UpdatePlatform(id string, updatedPlatform *t
 		return nil, err
 	}
 	result := &types.Platform{}
-	return result, client.update(result, requestBody, id, "/v1/platforms/")
+	return result, client.update(result, requestBody, id, web.PlatformsURL)
 }
 
 func (client *serviceManagerClient) update(result interface{}, body []byte, id, path string) error {
 	buffer := bytes.NewBuffer(body)
-	resp, err := client.Call(http.MethodPatch, path+id, buffer)
+	resp, err := client.Call(http.MethodPatch, path + "/" + id, buffer)
 	if err != nil {
 		return err
 	}

--- a/pkg/smclient/client_test.go
+++ b/pkg/smclient/client_test.go
@@ -48,32 +48,32 @@ var _ = Describe("Service Manager Client test", func() {
 	}
 
 	broker := &types.Broker{
-		Name:        "test broker",
+		Name:        "test-broker",
 		URL:         "http://test-url.com",
 		Credentials: &types.Credentials{Basic: types.Basic{User: "test user", Password: "test password"}},
 	}
 
 	initialOffering := &types.ServiceOffering{
 		ID: "offeringID",
-		Name: "initial offering",
+		Name: "initial-offering",
 		Description: "Some description",
 		BrokerID: "id",
 	}
 
 	plan := &types.ServicePlan{
 		ID: "planID",
-		Name: "plan 1",
+		Name: "plan-1",
 		Description: "Sample Plan",
 		ServiceOfferingID: "offeringID",
 	}
 
 	resultOffering := &types.ServiceOffering{
 		ID: "offeringID",
-		Name: "initial offering",
+		Name: "initial-offering",
 		Description: "Some description",
 		Plans: []types.ServicePlan{*plan},
 		BrokerID: "id",
-		BrokerName: "test broker",
+		BrokerName: "test-broker",
 	}
 
 

--- a/pkg/smclient/client_test.go
+++ b/pkg/smclient/client_test.go
@@ -2,6 +2,7 @@ package smclient
 
 import (
 	"encoding/json"
+	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -109,7 +110,7 @@ var _ = Describe("Service Manager Client test", func() {
 		Context("When wrong token is used", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/service_brokers"},
+					{Method: http.MethodGet, Path: web.BrokersURL},
 				}
 			})
 			It("should fail to authentication", func() {
@@ -117,7 +118,7 @@ var _ = Describe("Service Manager Client test", func() {
 				_, err := client.ListBrokers()
 
 				Expect(err).Should(HaveOccurred())
-				Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + "/v1/service_brokers", StatusCode: http.StatusUnauthorized}))
+				Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.BrokersURL, StatusCode: http.StatusUnauthorized}))
 			})
 		})
 	})
@@ -127,7 +128,7 @@ var _ = Describe("Service Manager Client test", func() {
 			BeforeEach(func() {
 				responseBody, _ := json.Marshal(platform)
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodPost, Path: "/v1/platforms", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodPost, Path: web.PlatformsURL , ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should register successfully", func() {
@@ -146,7 +147,7 @@ var _ = Describe("Service Manager Client test", func() {
 					Name: true,
 				})
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodPost, Path: "/v1/platforms", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodPost, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should return error", func() {
@@ -162,7 +163,7 @@ var _ = Describe("Service Manager Client test", func() {
 				BeforeEach(func() {
 					responseBody, _ := json.Marshal(platform)
 					handlerDetails = []HandlerDetails{
-						{Method: http.MethodPost, Path: "/v1/platforms", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+						{Method: http.MethodPost, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 					}
 				})
 				It("should return error with status code", func() {
@@ -178,14 +179,14 @@ var _ = Describe("Service Manager Client test", func() {
 				BeforeEach(func() {
 					responseBody := []byte(`{ "description": "error"}`)
 					handlerDetails = []HandlerDetails{
-						{Method: http.MethodPost, Path: "/v1/platforms", ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+						{Method: http.MethodPost, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
 					}
 				})
 				It("should return error with url and description", func() {
 					responsePlatform, err := client.RegisterPlatform(platform)
 
 					Expect(err).Should(HaveOccurred())
-					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + "/v1/platforms", Description: "error", StatusCode: handlerDetails[0].ResponseStatusCode}))
+					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.PlatformsURL, Description: "error", StatusCode: handlerDetails[0].ResponseStatusCode}))
 					Expect(responsePlatform).To(BeNil())
 				})
 			})
@@ -194,14 +195,14 @@ var _ = Describe("Service Manager Client test", func() {
 				BeforeEach(func() {
 					responseBody := []byte(`{ "description": description", "error": "error"}`)
 					handlerDetails = []HandlerDetails{
-						{Method: http.MethodPost, Path: "/v1/platforms", ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+						{Method: http.MethodPost, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
 					}
 				})
 				It("should return error without url and description if invalid response body", func() {
 					responsePlatform, err := client.RegisterPlatform(platform)
 
 					Expect(err).Should(HaveOccurred())
-					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + "/v1/platforms", StatusCode: handlerDetails[0].ResponseStatusCode}))
+					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.PlatformsURL, StatusCode: handlerDetails[0].ResponseStatusCode}))
 					Expect(responsePlatform).To(BeNil())
 				})
 			})
@@ -222,7 +223,7 @@ var _ = Describe("Service Manager Client test", func() {
 			BeforeEach(func() {
 				responseBody, _ := json.Marshal(broker)
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodPost, Path: "/v1/service_brokers", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodPost, Path: web.BrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should register successfully", func() {
@@ -241,7 +242,7 @@ var _ = Describe("Service Manager Client test", func() {
 					Name: true,
 				})
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodPost, Path: "/v1/service_brokers", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodPost, Path: web.BrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should return error", func() {
@@ -257,7 +258,7 @@ var _ = Describe("Service Manager Client test", func() {
 				BeforeEach(func() {
 					responseBody, _ := json.Marshal(broker)
 					handlerDetails = []HandlerDetails{
-						{Method: http.MethodPost, Path: "/v1/service_brokers", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+						{Method: http.MethodPost, Path: web.BrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 					}
 				})
 				It("should return error with status code", func() {
@@ -273,14 +274,14 @@ var _ = Describe("Service Manager Client test", func() {
 				BeforeEach(func() {
 					responseBody := []byte(`{ "description": "description", "error": "error"}`)
 					handlerDetails = []HandlerDetails{
-						{Method: http.MethodPost, Path: "/v1/service_brokers", ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+						{Method: http.MethodPost, Path: web.BrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
 					}
 				})
 				It("should return error with url and description", func() {
 					responseBroker, err := client.RegisterBroker(broker)
 
 					Expect(err).Should(HaveOccurred())
-					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + "/v1/service_brokers", Description: "description",
+					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.BrokersURL, Description: "description",
 																	ErrorMessage: "error", StatusCode: handlerDetails[0].ResponseStatusCode}))
 					Expect(responseBroker).To(BeNil())
 				})
@@ -290,14 +291,14 @@ var _ = Describe("Service Manager Client test", func() {
 				BeforeEach(func() {
 					responseBody := []byte(`{ "description": description", "error": "error"}`)
 					handlerDetails = []HandlerDetails{
-						{Method: http.MethodPost, Path: "/v1/service_brokers", ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+						{Method: http.MethodPost, Path: web.BrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
 					}
 				})
 				It("should return error without url and description if invalid response body", func() {
 					responseBroker, err := client.RegisterBroker(broker)
 
 					Expect(err).Should(HaveOccurred())
-					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + "/v1/service_brokers", StatusCode: handlerDetails[0].ResponseStatusCode}))
+					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.BrokersURL, StatusCode: handlerDetails[0].ResponseStatusCode}))
 					Expect(responseBroker).To(BeNil())
 				})
 			})
@@ -321,7 +322,7 @@ var _ = Describe("Service Manager Client test", func() {
 				brokers := types.Brokers{Brokers: brokersArray}
 				responseBody, _ := json.Marshal(brokers)
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/service_brokers", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.BrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should return all", func() {
@@ -338,7 +339,7 @@ var _ = Describe("Service Manager Client test", func() {
 				brokers := types.Brokers{Brokers: brokersArray}
 				responseBody, _ := json.Marshal(brokers)
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/service_brokers", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.BrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should return empty array", func() {
@@ -351,7 +352,7 @@ var _ = Describe("Service Manager Client test", func() {
 		Context("when invalid status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/service_brokers", ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodGet, Path: web.BrokersURL, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should handle status code != 200", func() {
@@ -364,13 +365,13 @@ var _ = Describe("Service Manager Client test", func() {
 		Context("when invalid status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/service_brokers", ResponseStatusCode: http.StatusBadRequest},
+					{Method: http.MethodGet, Path: web.BrokersURL, ResponseStatusCode: http.StatusBadRequest},
 				}
 			})
 			It("should handle status code > 299", func() {
 				_, err := client.ListBrokers()
 				Expect(err).Should(HaveOccurred())
-				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + "/v1/service_brokers"}))
+				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.BrokersURL}))
 			})
 		})
 	})
@@ -383,7 +384,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody, _ := json.Marshal(platforms)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/platforms", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should return all", func() {
@@ -401,7 +402,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody, _ := json.Marshal(platforms)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/platforms", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should return empty array", func() {
@@ -414,7 +415,7 @@ var _ = Describe("Service Manager Client test", func() {
 		Context("when invalid status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/platforms", ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodGet, Path: web.PlatformsURL, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should handle status code != 200", func() {
@@ -426,13 +427,13 @@ var _ = Describe("Service Manager Client test", func() {
 		Context("when invalid status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/platforms", ResponseStatusCode: http.StatusBadRequest},
+					{Method: http.MethodGet, Path: web.PlatformsURL, ResponseStatusCode: http.StatusBadRequest},
 				}
 			})
 			It("should handle status code > 299", func() {
 				_, err := client.ListPlatforms()
 				Expect(err).Should(HaveOccurred())
-				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + "/v1/platforms"}))
+				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.PlatformsURL}))
 			})
 		})
 	})
@@ -449,9 +450,9 @@ var _ = Describe("Service Manager Client test", func() {
 				brokerResponseBody, _ := json.Marshal(broker)
 
 				handlerDetails = []HandlerDetails {
-					{Method: http.MethodGet, Path: "/v1/service_offerings", ResponseBody: offeringResponseBody, ResponseStatusCode: http.StatusOK},
-					{Method: http.MethodGet, Path: "/v1/service_plans", ResponseBody: plansResponseBody, ResponseStatusCode: http.StatusOK},
-					{Method: http.MethodGet, Path: "/v1/service_brokers/", ResponseBody: brokerResponseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.ServiceOfferingsURL, ResponseBody: offeringResponseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.ServicePlansURL, ResponseBody: plansResponseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.BrokersURL + "/", ResponseBody: brokerResponseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should return all with plans and broker name populated", func() {
@@ -468,7 +469,7 @@ var _ = Describe("Service Manager Client test", func() {
 				offeringResponseBody, _ := json.Marshal(offerings)
 
 				handlerDetails = []HandlerDetails {
-					{Method: http.MethodGet, Path: "/v1/service_offerings", ResponseBody: offeringResponseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.ServiceOfferingsURL, ResponseBody: offeringResponseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should return empty array", func() {
@@ -481,7 +482,7 @@ var _ = Describe("Service Manager Client test", func() {
 		Context("when invalid status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails {
-					{Method: http.MethodGet, Path: "/v1/service_offerings", ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodGet, Path: web.ServiceOfferingsURL, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should handle status code != 200", func() {
@@ -494,13 +495,13 @@ var _ = Describe("Service Manager Client test", func() {
 		Context("when invalid status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails {
-					{Method: http.MethodGet, Path: "/v1/service_offerings", ResponseStatusCode: http.StatusBadRequest},
+					{Method: http.MethodGet, Path: web.ServiceOfferingsURL, ResponseStatusCode: http.StatusBadRequest},
 				}
 			})
 			It("should handle status code > 299", func() {
 				_, err := client.ListOfferings()
 				Expect(err).Should(HaveOccurred())
-				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + "/v1/service_offerings"}))
+				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.ServiceOfferingsURL}))
 			})
 		})
 
@@ -512,7 +513,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte("{}")
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: "/v1/service_brokers/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodDelete, Path: web.BrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should be successfully removed", func() {
@@ -526,7 +527,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte("{}")
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: "/v1/service_brokers/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodDelete, Path: web.BrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should handle error", func() {
@@ -541,13 +542,13 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte(`{ "description": "Broker not found" }`)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: "/v1/service_brokers/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+					{Method: http.MethodDelete, Path: web.BrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
 				}
 			})
 			It("should handle error", func() {
 				err := client.DeleteBroker("id")
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(errors.ResponseError{Description: "Broker not found", URL: smServer.URL + "/v1/service_brokers/id", StatusCode: http.StatusNotFound}))
+				Expect(err).Should(MatchError(errors.ResponseError{Description: "Broker not found", URL: smServer.URL + web.BrokersURL + "/id", StatusCode: http.StatusNotFound}))
 			})
 		})
 	})
@@ -558,7 +559,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte("{}")
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: "/v1/platforms/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodDelete, Path: web.PlatformsURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should be successfully removed", func() {
@@ -572,7 +573,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte("{}")
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: "/v1/platforms/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodDelete, Path: web.PlatformsURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should handle error", func() {
@@ -587,13 +588,13 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte(`{ "description": "Platform not found" }`)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: "/v1/platforms/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+					{Method: http.MethodDelete, Path: web.PlatformsURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
 				}
 			})
 			It("should handle error", func() {
 				err := client.DeletePlatform("id")
 				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError(errors.ResponseError{Description: "Platform not found", URL: smServer.URL + "/v1/platforms/id", StatusCode: http.StatusNotFound}))
+				Expect(err).Should(MatchError(errors.ResponseError{Description: "Platform not found", URL: smServer.URL + web.PlatformsURL + "/id", StatusCode: http.StatusNotFound}))
 			})
 		})
 	})
@@ -608,7 +609,7 @@ var _ = Describe("Service Manager Client test", func() {
 				}`)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodPatch, Path: "/v1/service_brokers/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodPatch, Path: web.BrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should be successfully removed", func() {
@@ -623,7 +624,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte(`{}`)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodPatch, Path: "/v1/service_brokers/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+					{Method: http.MethodPatch, Path: web.BrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
 				}
 			})
 			It("should handle error", func() {
@@ -639,7 +640,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte(`{"token_issuer_url": "http://uaa.com"}`)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/info", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.InfoURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should get the right issuer and default token basic auth", func() {
@@ -654,7 +655,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte(`{"token_issuer_url": "http://uaa.com", "token_basic_auth": false}`)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/info", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.InfoURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should get the right value", func() {
@@ -669,13 +670,13 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte(``)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/info", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+					{Method: http.MethodGet, Path: web.InfoURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
 				}
 			})
 			It("should get an error", func() {
 				_, err := client.GetInfo()
 				Expect(err).Should(HaveOccurred())
-				Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + "/v1/info", StatusCode: http.StatusNotFound}))
+				Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.InfoURL, StatusCode: http.StatusNotFound}))
 			})
 		})
 
@@ -684,7 +685,7 @@ var _ = Describe("Service Manager Client test", func() {
 				responseBody := []byte(`{"token_issuer":}`)
 
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodGet, Path: "/v1/info", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					{Method: http.MethodGet, Path: web.InfoURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should get an error", func() {

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -2,12 +2,12 @@
 package smclientfakes
 
 import (
-	io "io"
-	http "net/http"
-	sync "sync"
+	"io"
+	"net/http"
+	"sync"
 
-	smclient "github.com/Peripli/service-manager-cli/pkg/smclient"
-	types "github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/Peripli/service-manager-cli/pkg/smclient"
+	"github.com/Peripli/service-manager-cli/pkg/types"
 )
 
 type FakeClient struct {
@@ -70,6 +70,18 @@ type FakeClient struct {
 	}
 	listBrokersReturnsOnCall map[int]struct {
 		result1 *types.Brokers
+		result2 error
+	}
+	ListOfferingsStub        func() (*types.ServiceOfferings, error)
+	listOfferingsMutex       sync.RWMutex
+	listOfferingsArgsForCall []struct {
+	}
+	listOfferingsReturns struct {
+		result1 *types.ServiceOfferings
+		result2 error
+	}
+	listOfferingsReturnsOnCall map[int]struct {
+		result1 *types.ServiceOfferings
 		result2 error
 	}
 	ListPlatformsStub        func() (*types.Platforms, error)
@@ -437,6 +449,61 @@ func (fake *FakeClient) ListBrokersReturnsOnCall(i int, result1 *types.Brokers, 
 	}{result1, result2}
 }
 
+func (fake *FakeClient) ListOfferings() (*types.ServiceOfferings, error) {
+	fake.listOfferingsMutex.Lock()
+	ret, specificReturn := fake.listOfferingsReturnsOnCall[len(fake.listOfferingsArgsForCall)]
+	fake.listOfferingsArgsForCall = append(fake.listOfferingsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListOfferings", []interface{}{})
+	fake.listOfferingsMutex.Unlock()
+	if fake.ListOfferingsStub != nil {
+		return fake.ListOfferingsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listOfferingsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListOfferingsCallCount() int {
+	fake.listOfferingsMutex.RLock()
+	defer fake.listOfferingsMutex.RUnlock()
+	return len(fake.listOfferingsArgsForCall)
+}
+
+func (fake *FakeClient) ListOfferingsCalls(stub func() (*types.ServiceOfferings, error)) {
+	fake.listOfferingsMutex.Lock()
+	defer fake.listOfferingsMutex.Unlock()
+	fake.ListOfferingsStub = stub
+}
+
+func (fake *FakeClient) ListOfferingsReturns(result1 *types.ServiceOfferings, result2 error) {
+	fake.listOfferingsMutex.Lock()
+	defer fake.listOfferingsMutex.Unlock()
+	fake.ListOfferingsStub = nil
+	fake.listOfferingsReturns = struct {
+		result1 *types.ServiceOfferings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListOfferingsReturnsOnCall(i int, result1 *types.ServiceOfferings, result2 error) {
+	fake.listOfferingsMutex.Lock()
+	defer fake.listOfferingsMutex.Unlock()
+	fake.ListOfferingsStub = nil
+	if fake.listOfferingsReturnsOnCall == nil {
+		fake.listOfferingsReturnsOnCall = make(map[int]struct {
+			result1 *types.ServiceOfferings
+			result2 error
+		})
+	}
+	fake.listOfferingsReturnsOnCall[i] = struct {
+		result1 *types.ServiceOfferings
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) ListPlatforms() (*types.Platforms, error) {
 	fake.listPlatformsMutex.Lock()
 	ret, specificReturn := fake.listPlatformsReturnsOnCall[len(fake.listPlatformsArgsForCall)]
@@ -759,6 +826,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.getInfoMutex.RUnlock()
 	fake.listBrokersMutex.RLock()
 	defer fake.listBrokersMutex.RUnlock()
+	fake.listOfferingsMutex.RLock()
+	defer fake.listOfferingsMutex.RUnlock()
 	fake.listPlatformsMutex.RLock()
 	defer fake.listPlatformsMutex.RUnlock()
 	fake.registerBrokerMutex.RLock()

--- a/pkg/types/service_offering.go
+++ b/pkg/types/service_offering.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ServiceOffering defines the data of a service offering.
+type ServiceOffering struct {
+	ID          string `json:"id,omitempty" yaml:"id,omitempty"`
+	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+
+	Bindable             bool   `json:"bindable,omitempty" yaml:"bindable,omitempty"`
+	InstancesRetrievable bool   `json:"instances_retrievable,omitempty" yaml:"instances_retrievable,omitempty"`
+	BindingsRetrievable  bool   `json:"bindings_retrievable,omitempty" yaml:"bindings_retrievable,omitempty"`
+	PlanUpdatable        bool   `json:"plan_updateable,omitempty" yaml:"plan_updateable,omitempty"`
+	CatalogID            string `json:"catalog_id,omitempty" yaml:"catalog_id,omitempty"`
+	CatalogName          string `json:"catalog_name,omitempty" yaml:"catalog_name,omitempty"`
+
+	Tags     json.RawMessage `json:"tags,omitempty" yaml:"-"`
+	Requires json.RawMessage `json:"requires,omitempty" yaml:"-"`
+	Metadata json.RawMessage `json:"metadata,omitempty" yaml:"-"`
+
+	BrokerID   string        `json:"broker_id,omitempty" yaml:"broker_id,omitempty"`
+	BrokerName string        `json:"broker_name,omitempty" yaml:"broker_name,omitempty"`
+	Plans      []ServicePlan `json:"plans,omitempty" yaml:"plans,omitempty"`
+}
+
+// Message title of the table
+func (so *ServiceOffering) Message() string {
+	return ""
+}
+
+// IsEmpty whether the structure is empty
+func (so *ServiceOffering) IsEmpty() bool {
+	return false
+}
+
+// TableData returns the data to populate a table
+func (so *ServiceOffering) TableData() *TableData {
+	result := &TableData{}
+	result.Headers = []string{"Name", "Plans", "Description", "Broker Name", "Broker ID"}
+
+	plans := make([]string, len(so.Plans))
+	for i, v := range so.Plans {
+		plans[i] = v.Name
+	}
+
+	row := []string{so.Name, strings.Join(plans, ", "), so.Description, so.BrokerName, so.BrokerID}
+	result.Data = append(result.Data, row)
+
+	return result
+}
+
+// ServiceOfferings wraps an array of service offerings
+type ServiceOfferings struct {
+	ServiceOfferings []ServiceOffering `json:"service_offerings" yaml:"service_offerings"`
+}
+
+// Message title of the table
+func (so *ServiceOfferings) Message() string {
+	var msg string
+
+	if len(so.ServiceOfferings) == 0 {
+		msg = "There are no service offerings."
+	} else if len(so.ServiceOfferings) == 1 {
+		msg = "One service offering."
+	} else {
+		msg = fmt.Sprintf("%d service offerings.", len(so.ServiceOfferings))
+	}
+
+	return msg
+}
+
+// IsEmpty whether the structure is empty
+func (so *ServiceOfferings) IsEmpty() bool {
+	return len(so.ServiceOfferings) == 0
+}
+
+// TableData returns the data to populate a table
+func (so *ServiceOfferings) TableData() *TableData {
+
+	result := &TableData{}
+	result.Headers = []string{"Name", "Plans", "Description", "Broker Name", "Broker ID"}
+
+	for _, v := range so.ServiceOfferings {
+		plans := make([]string, len(v.Plans))
+		for i, v := range v.Plans {
+			plans[i] = v.Name
+		}
+
+		row := []string{v.Name, strings.Join(plans, ", "), v.Description, v.BrokerName, v.BrokerID}
+		result.Data = append(result.Data, row)
+	}
+
+	return result
+}

--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ServicePlan defines the data of a service plan.
+type ServicePlan struct {
+	ID          string `json:"id,omitempty" yaml:"id,omitempty"`
+	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+
+	CatalogID     string `json:"catalog_id,omitempty" yaml:"catalog_id,omitempty"`
+	CatalogName   string `json:"catalog_name,omitempty" yaml:"catalog_name,omitempty"`
+	Free          bool   `json:"free,omitempty" yaml:"free,omitempty"`
+	Bindable      bool   `json:"bindable,omitempty" yaml:"bindable,omitempty"`
+	PlanUpdatable bool   `json:"plan_updateable,omitempty" yaml:"plan_updateable,omitempty"`
+
+	Metadata json.RawMessage `json:"metadata,omitempty" yaml:"-"`
+	Schemas  json.RawMessage `json:"schemas,omitempty" yaml:"-"`
+
+	ServiceOfferingID string `json:"service_offering_id,omitempty" yaml:"service_offering_id,omitempty"`
+}
+
+// Message title of the table
+func (sp *ServicePlan) Message() string {
+	return ""
+}
+
+// IsEmpty whether the structure is empty
+func (sp *ServicePlan) IsEmpty() bool {
+	return false
+}
+
+// TableData returns the data to populate a table
+func (sp *ServicePlan) TableData() *TableData {
+	result := &TableData{}
+	result.Headers = []string{"Plan", "Description"}
+
+	row := []string{sp.Name, sp.Description}
+	result.Data = append(result.Data, row)
+
+	return result
+}
+
+// ServicePlans wraps an array of service plans
+type ServicePlans struct {
+	ServicePlans []ServicePlan `json:"service_plans" yaml:"service_plans"`
+}
+
+// Message title of the table
+func (sp *ServicePlans) Message() string {
+	var msg string
+
+	if len(sp.ServicePlans) == 0 {
+		msg = "There are no service plans for this service offering."
+	} else if len(sp.ServicePlans) == 1 {
+		msg = "One service plan for this service offering."
+	} else {
+		msg = fmt.Sprintf("%d service plans for this service offering.", len(sp.ServicePlans))
+	}
+
+	return msg
+}
+
+// IsEmpty whether the structure is empty
+func (sp *ServicePlans) IsEmpty() bool {
+	return len(sp.ServicePlans) == 0
+}
+
+// TableData returns the data to populate a table
+func (sp *ServicePlans) TableData() *TableData {
+	result := &TableData{}
+	result.Headers = []string{"Plan", "Description"}
+
+	for _, v := range sp.ServicePlans {
+		row := []string{v.Name, v.Description}
+		result.Data = append(result.Data, row)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Motivation
Service Manager provides APIs for listing Service Offerings and Plans so the cli should be adapted.

## Approach
Introduced smctl list-offerings (smctl lo) command for listing service offerings and --service (-s) flag for detailed view of the offering's plans.

#### Pull Request status

- [x] Initial implementation
- [x] Unit tests