### PR TITLE
Label command for resource labeling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,11 +2,12 @@
 
 
 [[projects]]
-  digest = "1:4ccd6c86ba13644b9d5eb501513fd26fc7c1309caabebb1a87ff7dd779c8943a"
+  digest = "1:fbb5481153a080502f500f90640c13f0edcea73f78883a315108464e9d6a4837"
   name = "github.com/Peripli/service-manager"
   packages = [
     "pkg/health",
     "pkg/log",
+    "pkg/query",
     "pkg/types",
     "pkg/util",
     "pkg/util/slice",
@@ -246,6 +247,30 @@
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:7df351557a6d5c30804e7d6f7ed87f2fccb0619c08fcc84869a93f22bec96c11"
+  name = "github.com/tidwall/gjson"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "eee0b6226f0d1db2675a176fdfaa8419bcad4ca8"
+  version = "v1.2.1"
+
+[[projects]]
+  digest = "1:8453ddbed197809ee8ca28b06bd04e127bec9912deb4ba451fea7a1eca578328"
+  name = "github.com/tidwall/match"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "33827db735fff6510490d69a8622612558a557ed"
+  version = "v1.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ddfe0a54e5f9b29536a6d7b2defa376f2cb2b6e4234d676d7ff214d5b097cb50"
+  name = "github.com/tidwall/pretty"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1166b9ac2b65e46a43d8618d30d1554f4652d49b"
+
+[[projects]]
   branch = "master"
   digest = "1:bbe51412d9915d64ffaa96b51d409e070665efc5194fcf145c4a27d4133107a4"
   name = "golang.org/x/crypto"
@@ -365,6 +390,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Peripli/service-manager/pkg/log",
+    "github.com/Peripli/service-manager/pkg/query",
     "github.com/Peripli/service-manager/pkg/types",
     "github.com/Peripli/service-manager/pkg/web",
     "github.com/onsi/ginkgo",

--- a/internal/cmd/label/label.go
+++ b/internal/cmd/label/label.go
@@ -7,6 +7,7 @@ import (
 	resperror "github.com/Peripli/service-manager-cli/pkg/errors"
 	"github.com/Peripli/service-manager-cli/pkg/types"
 	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/web"
 	"github.com/spf13/cobra"
 	"strings"
 )
@@ -15,7 +16,7 @@ import (
 type Cmd struct {
 	*cmd.Context
 
-	resource     string
+	resourcePath string
 	id           string
 	labelChanges types.LabelChanges
 }
@@ -43,8 +44,8 @@ func (c *Cmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 func (c *Cmd) Validate(args []string) error {
 
 	resources := map[string]string{
-		"platform": "platforms",
-		"broker":   "brokers",
+		"platform": web.PlatformsURL,
+		"broker":   web.ServiceBrokersURL,
 	}
 
 	operations := map[string]string{
@@ -55,11 +56,11 @@ func (c *Cmd) Validate(args []string) error {
 	}
 
 	if len(args) < 4 {
-		return fmt.Errorf("resource type, name, operation and value are required")
+		return fmt.Errorf("resource type, id, operation and value are required")
 	}
 
 	if v, ok := resources[args[0]]; ok {
-		c.resource = v
+		c.resourcePath = v
 		c.id = args[1]
 	} else {
 		return fmt.Errorf("unknown resource")
@@ -82,7 +83,7 @@ func (c *Cmd) Validate(args []string) error {
 
 // Run runs the command's logic
 func (c *Cmd) Run() error {
-	err := c.Client.Label(c.resource, c.id, &c.labelChanges)
+	err := c.Client.Label(c.resourcePath, c.id, &c.labelChanges)
 	if responseErr, ok := err.(resperror.ResponseError); ok {
 		return fmt.Errorf(responseErr.Description)
 	} else if err != nil {

--- a/internal/cmd/label/label.go
+++ b/internal/cmd/label/label.go
@@ -59,6 +59,10 @@ func (c *Cmd) Validate(args []string) error {
 		return fmt.Errorf("resource type, id, operation and value are required")
 	}
 
+	if len(args) > 4 {
+		return fmt.Errorf("too much arguments, in case you have whitespaces in some of the arguments consider enclosig it with single quotes")
+	}
+
 	if v, ok := resources[args[0]]; ok {
 		c.resourcePath = v
 		c.id = args[1]

--- a/internal/cmd/label/label.go
+++ b/internal/cmd/label/label.go
@@ -15,8 +15,8 @@ import (
 type Cmd struct {
 	*cmd.Context
 
-	resource    string
-	id        string
+	resource     string
+	id           string
 	labelChanges types.LabelChanges
 }
 
@@ -28,7 +28,7 @@ func NewLabelCmd(context *cmd.Context) *Cmd {
 // Prepare returns cobra command
 func (c *Cmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 	result := &cobra.Command{
-		Use:   "label [resource] [name] [operation] [key=value1,value2,...]",
+		Use:   "label [resource] [id] [operation] [key=value1,value2,...]",
 		Short: "Label resource",
 		Long:  "Label resource",
 

--- a/internal/cmd/label/label.go
+++ b/internal/cmd/label/label.go
@@ -1,0 +1,99 @@
+package label
+
+import (
+	"fmt"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	resperror "github.com/Peripli/service-manager-cli/pkg/errors"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// Cmd wraps smctl label command
+type Cmd struct {
+	*cmd.Context
+
+	resource    string
+	id        string
+	labelChanges types.LabelChanges
+}
+
+// NewLabelCmd returns new label command with context
+func NewLabelCmd(context *cmd.Context) *Cmd {
+	return &Cmd{Context: context, labelChanges: types.LabelChanges{}}
+}
+
+// Prepare returns cobra command
+func (c *Cmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		Use:   "label [resource] [name] [operation] [key=value1,value2,...]",
+		Short: "Label resource",
+		Long:  "Label resource",
+
+		PreRunE: prepare(c, c.Context),
+		RunE:    cmd.RunE(c),
+	}
+
+	return result
+}
+
+// Validate validates command's arguments
+func (c *Cmd) Validate(args []string) error {
+
+	resources := map[string]string{
+		"platform": "platforms",
+		"broker":   "brokers",
+	}
+
+	operations := map[string]string{
+		"add":           "add",
+		"remove":        "remove",
+		"add-values":    "add_values",
+		"remove-values": "remove_values",
+	}
+
+	if len(args) < 4 {
+		return fmt.Errorf("resource type, name, operation and value are required")
+	}
+
+	if v, ok := resources[args[0]]; ok {
+		c.resource = v
+		c.id = args[1]
+	} else {
+		return fmt.Errorf("unknown resource")
+	}
+
+	labelChange := &query.LabelChange{}
+
+	if v, ok := operations[args[2]]; ok {
+		labelChange.Operation = query.LabelOperation(v)
+	} else {
+		return fmt.Errorf("unknown operation")
+	}
+	keyValueSeparatorIndex := strings.Index(args[3], "=")
+	labelChange.Key = args[3][:keyValueSeparatorIndex]
+	values := args[3][keyValueSeparatorIndex+1:]
+	labelChange.Values = strings.Split(values, ",")
+	c.labelChanges.LabelChanges = append(c.labelChanges.LabelChanges, labelChange)
+	return nil
+}
+
+// Run runs the command's logic
+func (c *Cmd) Run() error {
+	err := c.Client.Label(c.resource, c.id, &c.labelChanges)
+	if responseErr, ok := err.(resperror.ResponseError); ok {
+		return fmt.Errorf(responseErr.Description)
+	} else if err != nil {
+		return err
+	}
+
+	output.PrintMessage(c.Output, "Resource labeled successfully!")
+	return nil
+}
+
+// HideUsage hide command's usage
+func (c *Cmd) HideUsage() bool {
+	return true
+}

--- a/internal/cmd/label/label_test.go
+++ b/internal/cmd/label/label_test.go
@@ -85,6 +85,21 @@ var _ = Describe("Label Command test", func() {
 			})
 		})
 
+		Context("with more than 4 arguments", func() {
+			It("should return error", func() {
+				err := invalidLabelExecution("platform", "id", "add-values", "key=value", "redundant")
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("too much arguments, in case you have whitespaces in some of the arguments consider enclosig it with single quotes"))
+			})
+
+			It("should not call SM", func() {
+				err := invalidLabelExecution("platform", "id", "add-values", "key=value", "redundant")
+				c := client.LabelCallCount()
+				Expect(err).Should(HaveOccurred())
+				Expect(c).To(Equal(0))
+			})
+		})
+
 		Context("with unknown resource provided", func() {
 			It("should return error", func() {
 				err := invalidLabelExecution("invalid resource", "id", "add", "key=val")

--- a/internal/cmd/label/label_test.go
+++ b/internal/cmd/label/label_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Label Command test", func() {
 	Describe("Valid Invocation", func() {
 		Context("with valid arguments provided", func() {
 			It("should label resource successfully", func() {
-				err := validLabelExecution("platform", "id", "add", "key=val1,val2,val3")
+				err := validLabelExecution("platform", "id", "add", "key", "--val", "val1", "--val", "val2", "--val", "val3")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buffer.String()).To(ContainSubstring("Resource labeled successfully!"))
 			})
@@ -58,7 +58,7 @@ var _ = Describe("Label Command test", func() {
 				labelChanges = &types.LabelChanges{
 					LabelChanges: []*query.LabelChange{{Key: "key", Operation: "add_values", Values: []string{"val1", "val2", "val3"}}},
 				}
-				err := validLabelExecution("platform", "id", "add-values", "key=val1,val2,val3")
+				err := validLabelExecution("platform", "id", "add-values", "key", "--val", "val1","--val", "val2","--val", "val3")
 
 				Expect(err).ShouldNot(HaveOccurred())
 				resourcePath, id, changes := client.LabelArgsForCall(0)
@@ -74,7 +74,7 @@ var _ = Describe("Label Command test", func() {
 			It("should return error", func() {
 				err := invalidLabelExecution()
 				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("resource type, id, operation and value are required"))
+				Expect(err.Error()).To(ContainSubstring("resource type, id, operation, key and values are required"))
 			})
 
 			It("should not call SM", func() {
@@ -87,13 +87,13 @@ var _ = Describe("Label Command test", func() {
 
 		Context("with more than 4 arguments", func() {
 			It("should return error", func() {
-				err := invalidLabelExecution("platform", "id", "add-values", "key=value", "redundant")
+				err := invalidLabelExecution("platform", "id", "add-values", "key", "--val", "value", "redundant")
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("too much arguments, in case you have whitespaces in some of the arguments consider enclosig it with single quotes"))
 			})
 
 			It("should not call SM", func() {
-				err := invalidLabelExecution("platform", "id", "add-values", "key=value", "redundant")
+				err := invalidLabelExecution("platform", "id", "add-values", "key", "--val", "value", "redundant")
 				c := client.LabelCallCount()
 				Expect(err).Should(HaveOccurred())
 				Expect(c).To(Equal(0))
@@ -102,12 +102,12 @@ var _ = Describe("Label Command test", func() {
 
 		Context("with unknown resource provided", func() {
 			It("should return error", func() {
-				err := invalidLabelExecution("invalid resource", "id", "add", "key=val")
+				err := invalidLabelExecution("invalid resource", "id", "add", "key", "--val", "value")
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unknown resource"))
 			})
 			It("should not call SM", func() {
-				err := invalidLabelExecution("invalid resource", "id", "add", "key=val")
+				err := invalidLabelExecution("invalid resource", "id", "add", "key", "--val", "value")
 				c := client.LabelCallCount()
 				Expect(err).Should(HaveOccurred())
 				Expect(c).To(Equal(0))
@@ -116,12 +116,12 @@ var _ = Describe("Label Command test", func() {
 
 		Context("with unknown operation provided", func() {
 			It("should return error", func() {
-				err := invalidLabelExecution("platform", "id", "invalid", "key=val")
+				err := invalidLabelExecution("platform", "id", "invalid", "key", "--val", "value")
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unknown operation"))
 			})
 			It("should not call SM", func() {
-				err := invalidLabelExecution("platform", "id", "invalid", "key=val")
+				err := invalidLabelExecution("platform", "id", "invalid", "key", "--val", "value")
 				c := client.LabelCallCount()
 				Expect(err).Should(HaveOccurred())
 				Expect(c).To(Equal(0))
@@ -133,7 +133,7 @@ var _ = Describe("Label Command test", func() {
 				expectedErr := errors.New("http client error")
 				client.LabelReturns(expectedErr)
 
-				err := invalidLabelExecution("platform", "id", "add", "key=val")
+				err := invalidLabelExecution("platform", "id", "add", "key", "--val", "value")
 
 				Expect(err).To(MatchError(expectedErr))
 			})
@@ -143,7 +143,7 @@ var _ = Describe("Label Command test", func() {
 			It("should return error's description", func() {
 				description := "HTTP response error"
 				client.LabelReturns(resperrors.ResponseError{Description: description})
-				err := invalidLabelExecution("platform", "id", "add", "key=val")
+				err := invalidLabelExecution("platform", "id", "add", "key", "--val", "value")
 				Expect(err).To(MatchError(description))
 
 			})

--- a/internal/cmd/label/label_test.go
+++ b/internal/cmd/label/label_test.go
@@ -1,0 +1,139 @@
+package label
+
+import (
+	"bytes"
+	"errors"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	resperrors "github.com/Peripli/service-manager-cli/pkg/errors"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/web"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestLabelCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("Label Command test", func() {
+
+	var client *smclientfakes.FakeClient
+	var command *Cmd
+	var buffer *bytes.Buffer
+	var labelChanges *types.LabelChanges
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		client = &smclientfakes.FakeClient{}
+		context := &cmd.Context{Output: buffer, Client: client}
+		command = NewLabelCmd(context)
+	})
+
+	validLabelExecution := func(args ...string) error {
+		client.LabelReturns(nil)
+		lc := command.Prepare(cmd.SmPrepare)
+		lc.SetArgs(args)
+		return lc.Execute()
+	}
+
+	invalidLabelExecution := func(args ...string) error {
+		lc := command.Prepare(cmd.SmPrepare)
+		lc.SetArgs(args)
+		return lc.Execute()
+	}
+
+	Describe("Valid Invocation", func() {
+		Context("with valid arguments provided", func() {
+			It("should label resource successfully", func() {
+				err := validLabelExecution("platform", "id", "add", "key=val1,val2,val3")
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring("Resource labeled successfully!"))
+			})
+
+			It("should pass arguments properly", func() {
+				labelChanges = &types.LabelChanges{
+					LabelChanges: []*query.LabelChange{{Key: "key", Operation: "add_values", Values: []string{"val1", "val2", "val3"}}},
+				}
+				err := validLabelExecution("platform", "id", "add-values", "key=val1,val2,val3")
+
+				Expect(err).ShouldNot(HaveOccurred())
+				resourcePath, id, changes := client.LabelArgsForCall(0)
+				Expect(resourcePath).To(Equal(web.PlatformsURL))
+				Expect(id).To(Equal("id"))
+				Expect(changes).To(Equal(labelChanges))
+			})
+		})
+	})
+
+	Describe("Invalid invocation", func() {
+		Context("with less than 4 required arguments", func() {
+			It("should return error", func() {
+				err := invalidLabelExecution()
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("resource type, id, operation and value are required"))
+			})
+
+			It("should not call SM", func() {
+				err := invalidLabelExecution()
+				c := client.LabelCallCount()
+				Expect(err).Should(HaveOccurred())
+				Expect(c).To(Equal(0))
+			})
+		})
+
+		Context("with unknown resource provided", func() {
+			It("should return error", func() {
+				err := invalidLabelExecution("invalid resource", "id", "add", "key=val")
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unknown resource"))
+			})
+			It("should not call SM", func() {
+				err := invalidLabelExecution("invalid resource", "id", "add", "key=val")
+				c := client.LabelCallCount()
+				Expect(err).Should(HaveOccurred())
+				Expect(c).To(Equal(0))
+			})
+		})
+
+		Context("with unknown operation provided", func() {
+			It("should return error", func() {
+				err := invalidLabelExecution("platform", "id", "invalid", "key=val")
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unknown operation"))
+			})
+			It("should not call SM", func() {
+				err := invalidLabelExecution("platform", "id", "invalid", "key=val")
+				c := client.LabelCallCount()
+				Expect(err).Should(HaveOccurred())
+				Expect(c).To(Equal(0))
+			})
+		})
+
+		Context("with error from http client", func() {
+			It("should return error", func() {
+				expectedErr := errors.New("http client error")
+				client.LabelReturns(expectedErr)
+
+				err := invalidLabelExecution("platform", "id", "add", "key=val")
+
+				Expect(err).To(MatchError(expectedErr))
+			})
+		})
+
+		Context("with http response error from http client", func() {
+			It("should return error's description", func() {
+				description := "HTTP response error"
+				client.LabelReturns(resperrors.ResponseError{Description: description})
+				err := invalidLabelExecution("platform", "id", "add", "key=val")
+				Expect(err).To(MatchError(description))
+
+			})
+		})
+
+	})
+
+})

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Peripli/service-manager-cli/internal/cmd/broker"
 	"github.com/Peripli/service-manager-cli/internal/cmd/curl"
 	"github.com/Peripli/service-manager-cli/internal/cmd/info"
+	"github.com/Peripli/service-manager-cli/internal/cmd/label"
 	"github.com/Peripli/service-manager-cli/internal/cmd/login"
 	"github.com/Peripli/service-manager-cli/internal/cmd/offering"
 	"github.com/Peripli/service-manager-cli/internal/cmd/platform"
@@ -70,6 +71,7 @@ func main() {
 			visibility.NewUpdateVisibilityCmd(context),
 			visibility.NewDeleteVisibilityCmd(context, os.Stdin),
 			offering.NewListOfferingsCmd(context),
+			label.NewLabelCmd(context),
 		},
 		PrepareFn: cmd.SmPrepare,
 	}

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -54,6 +54,7 @@ type Client interface {
 	UpdateBroker(string, *types.Broker) (*types.Broker, error)
 	UpdatePlatform(string, *types.Platform) (*types.Platform, error)
 	UpdateVisibility(string, *types.Visibility) (*types.Visibility, error)
+	Label(string, string, *types.LabelChanges) error
 
 	// Call makes HTTP request to the Service Manager server with authentication.
 	// It should be used only in case there is no already implemented method for such an operation
@@ -333,6 +334,24 @@ func (client *serviceManagerClient) update(resource interface{}, url string, id 
 	}
 
 	return httputil.UnmarshalResponse(resp, &result)
+}
+
+func (client *serviceManagerClient) Label(resource string, id string, change *types.LabelChanges) error {
+	requestBody, err := json.Marshal(change)
+	if err != nil {
+		return err
+	}
+	buffer := bytes.NewBuffer(requestBody)
+	response, err := client.Call(http.MethodPatch, "/v1/" + resource + "/" + id, buffer)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return errors.ResponseError{StatusCode: response.StatusCode}
+	}
+
+	return nil
 }
 
 func (client *serviceManagerClient) Call(method string, smpath string, body io.Reader) (*http.Response, error) {

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -336,13 +336,13 @@ func (client *serviceManagerClient) update(resource interface{}, url string, id 
 	return httputil.UnmarshalResponse(resp, &result)
 }
 
-func (client *serviceManagerClient) Label(resource string, id string, change *types.LabelChanges) error {
+func (client *serviceManagerClient) Label(resourcePath string, id string, change *types.LabelChanges) error {
 	requestBody, err := json.Marshal(change)
 	if err != nil {
 		return err
 	}
 	buffer := bytes.NewBuffer(requestBody)
-	response, err := client.Call(http.MethodPatch, "/v1/"+resource+"/"+id, buffer)
+	response, err := client.Call(http.MethodPatch, resourcePath+"/"+id, buffer)
 	if err != nil {
 		return err
 	}

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -342,7 +342,7 @@ func (client *serviceManagerClient) Label(resource string, id string, change *ty
 		return err
 	}
 	buffer := bytes.NewBuffer(requestBody)
-	response, err := client.Call(http.MethodPatch, "/v1/" + resource + "/" + id, buffer)
+	response, err := client.Call(http.MethodPatch, "/v1/"+resource+"/"+id, buffer)
 	if err != nil {
 		return err
 	}

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -93,6 +93,19 @@ type FakeClient struct {
 		result1 *types.Info
 		result2 error
 	}
+	LabelStub        func(string, string, *types.LabelChanges) error
+	labelMutex       sync.RWMutex
+	labelArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *types.LabelChanges
+	}
+	labelReturns struct {
+		result1 error
+	}
+	labelReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ListBrokersStub        func() (*types.Brokers, error)
 	listBrokersMutex       sync.RWMutex
 	listBrokersArgsForCall []struct {
@@ -700,6 +713,68 @@ func (fake *FakeClient) GetInfoReturnsOnCall(i int, result1 *types.Info, result2
 		result1 *types.Info
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClient) Label(arg1 string, arg2 string, arg3 *types.LabelChanges) error {
+	fake.labelMutex.Lock()
+	ret, specificReturn := fake.labelReturnsOnCall[len(fake.labelArgsForCall)]
+	fake.labelArgsForCall = append(fake.labelArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *types.LabelChanges
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Label", []interface{}{arg1, arg2, arg3})
+	fake.labelMutex.Unlock()
+	if fake.LabelStub != nil {
+		return fake.LabelStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.labelReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) LabelCallCount() int {
+	fake.labelMutex.RLock()
+	defer fake.labelMutex.RUnlock()
+	return len(fake.labelArgsForCall)
+}
+
+func (fake *FakeClient) LabelCalls(stub func(string, string, *types.LabelChanges) error) {
+	fake.labelMutex.Lock()
+	defer fake.labelMutex.Unlock()
+	fake.LabelStub = stub
+}
+
+func (fake *FakeClient) LabelArgsForCall(i int) (string, string, *types.LabelChanges) {
+	fake.labelMutex.RLock()
+	defer fake.labelMutex.RUnlock()
+	argsForCall := fake.labelArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) LabelReturns(result1 error) {
+	fake.labelMutex.Lock()
+	defer fake.labelMutex.Unlock()
+	fake.LabelStub = nil
+	fake.labelReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) LabelReturnsOnCall(i int, result1 error) {
+	fake.labelMutex.Lock()
+	defer fake.labelMutex.Unlock()
+	fake.LabelStub = nil
+	if fake.labelReturnsOnCall == nil {
+		fake.labelReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.labelReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeClient) ListBrokers() (*types.Brokers, error) {
@@ -1576,6 +1651,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.deleteVisibilityMutex.RUnlock()
 	fake.getInfoMutex.RLock()
 	defer fake.getInfoMutex.RUnlock()
+	fake.labelMutex.RLock()
+	defer fake.labelMutex.RUnlock()
 	fake.listBrokersMutex.RLock()
 	defer fake.listBrokersMutex.RUnlock()
 	fake.listBrokersWithQueryMutex.RLock()

--- a/pkg/types/label_changes.go
+++ b/pkg/types/label_changes.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/Peripli/service-manager/pkg/query"
+
+// LabelChanges wraps multiple labels change request body structure
+type LabelChanges struct {
+	LabelChanges []*query.LabelChange `json:"labels,omitempty"`
+}

--- a/pkg/types/label_changes.go
+++ b/pkg/types/label_changes.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package types
 
 import "github.com/Peripli/service-manager/pkg/query"


### PR DESCRIPTION
## Motivation
SM supports labels on resources but the CLI does not support labeling.

## Approach
This PR introduces new command for labeling resources.
`smctl label [resource] [id] [operation] [key=value1,value2,...] `
Where for now resource is one of the following:
- platform
- broker

And supported operations are:
- add
- remove
- add-values
- remove-values

#### Pull Request status

- [x] Initial implementation
- [x] Unit tests