### PR TITLE
SMCLI commands for managing plan visibilities.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:1f3bbcea7f7527432fea82bca006dcafa979cf59cb52dcf847ec1c7e57a4279f"
+  digest = "1:4ccd6c86ba13644b9d5eb501513fd26fc7c1309caabebb1a87ff7dd779c8943a"
   name = "github.com/Peripli/service-manager"
   packages = [
     "pkg/health",
@@ -13,8 +13,8 @@
     "pkg/web",
   ]
   pruneopts = "UT"
-  revision = "d9dcfac9658b892715c9b85bbee6f1ed88bf6969"
-  version = "v0.2.2"
+  revision = "b00c515277cde8158eb7fe0b3ff3b706a1ac0940"
+  version = "v0.2.3"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  version = "0.2.2"
+  version = "0.2.3"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/internal/cmd/broker/list_brokers_test.go
+++ b/internal/cmd/broker/list_brokers_test.go
@@ -113,10 +113,11 @@ var _ = Describe("List brokers command test", func() {
 			result := &types.Brokers{Brokers: []types.Broker{broker}}
 			client.ListBrokersWithQueryReturns(result, nil)
 
-			executeWithArgs([]string{"-o", "json"})
+			err := executeWithArgs([]string{"-o", "json"})
 
 			jsonByte, _ := json.MarshalIndent(result, "", "  ")
 			jsonOutputExpected := string(jsonByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
 		})
 
@@ -124,10 +125,11 @@ var _ = Describe("List brokers command test", func() {
 			result := &types.Brokers{Brokers: []types.Broker{broker}}
 			client.ListBrokersWithQueryReturns(result, nil)
 
-			executeWithArgs([]string{"-o", "yaml"})
+			err := executeWithArgs([]string{"-o", "yaml"})
 
 			yamlByte, _ := yaml.Marshal(result)
 			yamlOutputExpected := string(yamlByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
 		})
 	})

--- a/internal/cmd/offering/list_offerings_test.go
+++ b/internal/cmd/offering/list_offerings_test.go
@@ -168,10 +168,11 @@ var _ = Describe("List offerings command test", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
 			client.ListOfferingsWithQueryReturns(result, nil)
 
-			executeWithArgs([]string{"-o", "json"})
+			err := executeWithArgs([]string{"-o", "json"})
 
 			jsonByte, _ := json.MarshalIndent(result, "", "  ")
 			jsonOutputExpected := string(jsonByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
 		})
 
@@ -179,10 +180,11 @@ var _ = Describe("List offerings command test", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
 			client.ListOfferingsWithQueryReturns(result, nil)
 
-			executeWithArgs([]string{"-o", "yaml"})
+			err := executeWithArgs([]string{"-o", "yaml"})
 
 			yamlByte, _ := yaml.Marshal(result)
 			yamlOutputExpected := string(yamlByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
 		})
 
@@ -190,10 +192,11 @@ var _ = Describe("List offerings command test", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
 			client.ListOfferingsWithQueryReturns(result, nil)
 
-			executeWithArgs([]string{"-s", "offering1", "-o", "json"})
+			err := executeWithArgs([]string{"-s", "offering1", "-o", "json"})
 
 			jsonByte, _ := json.MarshalIndent(&types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans}, "", "  ")
 			jsonOutputExpected := string(jsonByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
 		})
 
@@ -201,10 +204,11 @@ var _ = Describe("List offerings command test", func() {
 			result := &types.ServiceOfferings{ServiceOfferings: []types.ServiceOffering{offering1}}
 			client.ListOfferingsWithQueryReturns(result, nil)
 
-			executeWithArgs([]string{"-s", "offering1", "-o", "yaml"})
+			err := executeWithArgs([]string{"-s", "offering1", "-o", "yaml"})
 
 			yamlByte, _ := yaml.Marshal(&types.ServicePlans{ServicePlans: result.ServiceOfferings[0].Plans})
 			yamlOutputExpected := string(yamlByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
 		})
 

--- a/internal/cmd/platform/delete_platform.go
+++ b/internal/cmd/platform/delete_platform.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 )
 
-// DeletePlatformCmd wraps the smctl list-brokers command
+// DeletePlatformCmd wraps the smctl delete-platform command
 type DeletePlatformCmd struct {
 	*cmd.Context
 
@@ -39,7 +39,7 @@ type DeletePlatformCmd struct {
 	names []string
 }
 
-// NewDeletePlatformCmd returns new list-brokers command with context
+// NewDeletePlatformCmd returns new delete-platform command with context
 func NewDeletePlatformCmd(context *cmd.Context, input io.Reader) *DeletePlatformCmd {
 	return &DeletePlatformCmd{Context: context, input: input}
 }

--- a/internal/cmd/platform/register_platform_test.go
+++ b/internal/cmd/platform/register_platform_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Register Platform Command test", func() {
 		command = NewRegisterPlatformCmd(context)
 	})
 
-	validRegisterPlatformExecution := func(args []string) error {
+	validRegisterPlatformExecution := func(args... string) error {
 		platform = &types.Platform{
 			ID:   "1234",
 			Name: args[0],
@@ -55,7 +55,7 @@ var _ = Describe("Register Platform Command test", func() {
 		return rpcCmd.Execute()
 	}
 
-	invalidRegisterPlatformCommandExecution := func(args []string) error {
+	invalidRegisterPlatformCommandExecution := func(args... string) error {
 		rpcCmd := command.Prepare(cmd.SmPrepare)
 		rpcCmd.SetArgs(args)
 		return rpcCmd.Execute()
@@ -64,7 +64,7 @@ var _ = Describe("Register Platform Command test", func() {
 	Describe("Valid request", func() {
 		Context("With necessary arguments provided", func() {
 			It("Platform should be registered", func() {
-				err := validRegisterPlatformExecution([]string{"platform", "cf"})
+				err := validRegisterPlatformExecution("platform", "cf")
 				tableOutputExpected := platform.TableData().String()
 
 				Expect(err).ShouldNot(HaveOccurred())
@@ -72,7 +72,7 @@ var _ = Describe("Register Platform Command test", func() {
 			})
 
 			It("Argument values should be as expected", func() {
-				err := validRegisterPlatformExecution([]string{"validName", "validType"})
+				err := validRegisterPlatformExecution("validName", "validType")
 
 				p := client.RegisterPlatformArgsForCall(0)
 
@@ -86,7 +86,7 @@ var _ = Describe("Register Platform Command test", func() {
 			It("Flag value should be as expected", func() {
 				args := []string{"validName", "validType", "--id", "1234"}
 
-				err := validRegisterPlatformExecution(args)
+				err := validRegisterPlatformExecution(args...)
 				platform := client.RegisterPlatformArgsForCall(0)
 
 				Expect(err).ShouldNot(HaveOccurred())
@@ -96,7 +96,7 @@ var _ = Describe("Register Platform Command test", func() {
 
 		Context("With description provided", func() {
 			It("Description value should be as expected", func() {
-				err := validRegisterPlatformExecution([]string{"validName", "validType", "validDescription"})
+				err := validRegisterPlatformExecution("validName", "validType", "validDescription")
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(command.platform.Description).To(Equal("validDescription"))
@@ -105,7 +105,7 @@ var _ = Describe("Register Platform Command test", func() {
 
 		Context("With json format flag", func() {
 			It("should be printed in json format", func() {
-				err := validRegisterPlatformExecution([]string{"platform", "cf", "--output", "json"})
+				err := validRegisterPlatformExecution("platform", "cf", "--output", "json")
 
 				jsonByte, _ := json.MarshalIndent(platform, "", "  ")
 				jsonOutputExpected := string(jsonByte) + "\n"
@@ -117,7 +117,7 @@ var _ = Describe("Register Platform Command test", func() {
 
 		Context("With yaml format flag", func() {
 			It("should be printed in yaml format", func() {
-				err := validRegisterPlatformExecution([]string{"platform", "cf", "--output", "yaml"})
+				err := validRegisterPlatformExecution("platform", "cf", "--output", "yaml")
 
 				yamlByte, _ := yaml.Marshal(platform)
 				yamlOutputExpected := string(yamlByte) + "\n"
@@ -131,7 +131,7 @@ var _ = Describe("Register Platform Command test", func() {
 	Describe("Invalid request", func() {
 		Context("With not enough arguments provided", func() {
 			It("Should return error", func() {
-				err := invalidRegisterPlatformCommandExecution([]string{"validName"})
+				err := invalidRegisterPlatformCommandExecution("validName")
 
 				Expect(err.Error()).To(ContainSubstring("requires at least 2 args"))
 			})
@@ -139,18 +139,19 @@ var _ = Describe("Register Platform Command test", func() {
 
 		Context("With error from http client", func() {
 			It("Should return error", func() {
-				client.RegisterPlatformReturns(nil, errors.New("Http Client Error"))
+				expectedErr := errors.New("http client error")
+				client.RegisterPlatformReturns(nil, expectedErr)
 
-				err := invalidRegisterPlatformCommandExecution([]string{"validName", "validType"})
+				err := invalidRegisterPlatformCommandExecution("validName", "validType")
 
-				Expect(err).To(MatchError("Http Client Error"))
+				Expect(err).To(MatchError(expectedErr.Error()))
 			})
 		})
 
 		Context("With invalid output format", func() {
 			It("should return error", func() {
 				invFormat := "invalid-format"
-				err := invalidRegisterPlatformCommandExecution([]string{"validName", "validUrl", "--output", invFormat})
+				err := invalidRegisterPlatformCommandExecution("validName", "validUrl", "--output", invFormat)
 
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).To(Equal("unknown output: " + invFormat))

--- a/internal/cmd/platform/register_platform_test.go
+++ b/internal/cmd/platform/register_platform_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Register Platform Command test", func() {
 		command = NewRegisterPlatformCmd(context)
 	})
 
-	validRegisterPlatformExecution := func(args... string) error {
+	validRegisterPlatformExecution := func(args ...string) error {
 		platform = &types.Platform{
 			ID:   "1234",
 			Name: args[0],
@@ -55,7 +55,7 @@ var _ = Describe("Register Platform Command test", func() {
 		return rpcCmd.Execute()
 	}
 
-	invalidRegisterPlatformCommandExecution := func(args... string) error {
+	invalidRegisterPlatformCommandExecution := func(args ...string) error {
 		rpcCmd := command.Prepare(cmd.SmPrepare)
 		rpcCmd.SetArgs(args)
 		return rpcCmd.Execute()

--- a/internal/cmd/visibility/delete_visibility.go
+++ b/internal/cmd/visibility/delete_visibility.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package visibility
+
+import (
+	"fmt"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/spf13/cobra"
+	"io"
+	"strings"
+)
+
+// DeleteVisibilityCmd wraps the smctl delete-visibility command
+type DeleteVisibilityCmd struct {
+	*cmd.Context
+
+	input io.Reader
+	force bool
+
+	ids []string
+}
+
+// NewDeleteVisibilityCmd returns new delete-visibility command with context
+func NewDeleteVisibilityCmd(context *cmd.Context, input io.Reader) *DeleteVisibilityCmd {
+	return &DeleteVisibilityCmd{Context: context, input: input}
+}
+
+// Validate validates command's arguments
+func (dv *DeleteVisibilityCmd) Validate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("id is required")
+	}
+
+	dv.ids = args
+
+	return nil
+}
+
+// Run runs the command's logic
+func (dv *DeleteVisibilityCmd) Run() error {
+	deletedVisibilities := make(map[string]bool)
+
+	for _, toDelete := range dv.ids {
+		err := dv.Client.DeleteVisibility(toDelete)
+		if err != nil {
+			output.PrintMessage(dv.Output, "Could not delete visibility %s. Reason %s\n", toDelete, err)
+		} else {
+			output.PrintMessage(dv.Output, "Visibility with id: %s successfully deleted\n", toDelete)
+			deletedVisibilities[toDelete] = true
+		}
+	}
+
+	for _, id := range dv.ids {
+		if !deletedVisibilities[id] {
+			output.PrintError(dv.Output, fmt.Errorf("visibility with id: %s was not found", id))
+		}
+	}
+
+	return nil
+}
+
+// HideUsage hide command's usage
+func (dv *DeleteVisibilityCmd) HideUsage() bool {
+	return true
+}
+
+// AskForConfirmation asks the user to confirm deletion
+func (dv *DeleteVisibilityCmd) AskForConfirmation() (bool, error) {
+	if !dv.force {
+		message := fmt.Sprintf("Do you really want to delete visibilities with ids [%s] (Y/n): ", strings.Join(dv.ids, ", "))
+		return cmd.CommonConfirmationPrompt(message, dv.Context, dv.input)
+	}
+	return true, nil
+}
+
+// PrintDeclineMessage prints confirmation decline message to the user
+func (dv *DeleteVisibilityCmd) PrintDeclineMessage() {
+	cmd.CommonPrintDeclineMessage(dv.Output)
+}
+
+// Prepare returns cobra command
+func (dv *DeleteVisibilityCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		Use:     "delete-visibility [id] <id2 <id3> ... <idN>>",
+		Aliases: []string{"dv"},
+		Short:   "Deletes visibility",
+		Long:    `Delete one or more visibilities by name.`,
+		PreRunE: prepare(dv, dv.Context),
+		RunE:    cmd.RunE(dv),
+	}
+
+	result.Flags().BoolVarP(&dv.force, "force", "f", false, "Force delete without confirmation")
+
+	return result
+}

--- a/internal/cmd/visibility/delete_visibility_test.go
+++ b/internal/cmd/visibility/delete_visibility_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Delete visibility command test", func() {
 		command = NewDeleteVisibilityCmd(context, promptBuffer)
 	})
 
-	executeWithArgs := func(args... string) error {
+	executeWithArgs := func(args ...string) error {
 		commandToRun := command.Prepare(cmd.SmPrepare)
 		commandToRun.SetArgs(args)
 

--- a/internal/cmd/visibility/delete_visibility_test.go
+++ b/internal/cmd/visibility/delete_visibility_test.go
@@ -1,0 +1,102 @@
+package visibility
+
+import (
+	"bytes"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/pkg/errors"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+	"testing"
+)
+
+func TestDeleteVisibilityCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("Delete visibility command test", func() {
+
+	var client *smclientfakes.FakeClient
+	var command *DeleteVisibilityCmd
+	var buffer *bytes.Buffer
+	var promptBuffer *bytes.Buffer
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		promptBuffer = &bytes.Buffer{}
+		client = &smclientfakes.FakeClient{}
+		context := &cmd.Context{Output: buffer, Client: client}
+		command = NewDeleteVisibilityCmd(context, promptBuffer)
+	})
+
+	executeWithArgs := func(args... string) error {
+		commandToRun := command.Prepare(cmd.SmPrepare)
+		commandToRun.SetArgs(args)
+
+		return commandToRun.Execute()
+	}
+
+	Context("when existing visibility is being deleted forcefully", func() {
+		It("should list success message", func() {
+			client.DeleteVisibilityReturns(nil)
+			err := executeWithArgs("id", "-f")
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Visibility with id: id successfully deleted"))
+		})
+	})
+
+	Context("when existing visibility is being deleted", func() {
+		It("should list success message when confirmed", func() {
+			client.DeleteVisibilityReturns(nil)
+			promptBuffer.WriteString("y")
+			err := executeWithArgs("id")
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Visibility with id: id successfully deleted"))
+		})
+
+		It("should print delete declined when declined", func() {
+			client.DeleteVisibilityReturns(nil)
+			promptBuffer.WriteString("n")
+			err := executeWithArgs("id")
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Delete declined"))
+		})
+	})
+
+	Context("when 2 visibilities are being deleted", func() {
+		It("should success for both of them", func() {
+			client.DeleteVisibilityReturns(nil)
+			err := executeWithArgs("id1", "id2", "-f")
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Visibility with id: id1 successfully deleted"))
+			Expect(buffer.String()).To(ContainSubstring("Visibility with id: id2 successfully deleted"))
+		})
+	})
+
+	Context("when non-existing visibility is being deleted", func() {
+		It("should return error message", func() {
+			expectedError := errors.ResponseError{StatusCode: http.StatusNotFound}
+			client.DeleteVisibilityReturns(expectedError)
+			err := executeWithArgs("id", "-f")
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("visibility with id: id was not found"))
+		})
+	})
+
+	Context("when no arguments are provided", func() {
+		It("should print required arguments", func() {
+			client.DeleteVisibilityReturns(nil)
+			err := executeWithArgs()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("id is required"))
+		})
+	})
+})

--- a/internal/cmd/visibility/list_visibilities.go
+++ b/internal/cmd/visibility/list_visibilities.go
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package visibility

--- a/internal/cmd/visibility/list_visibilities.go
+++ b/internal/cmd/visibility/list_visibilities.go
@@ -15,3 +15,59 @@
  */
 
 package visibility
+
+import (
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// ListVisibilityCmd wraps the smctl list-visibilities command
+type ListVisibilitiesCmd struct {
+	*cmd.Context
+
+	outputFormat output.Format
+}
+
+// NewListVisibilitiesCmd returns new list-visibilities command with context
+func NewListVisibilitiesCmd(context *cmd.Context) *ListVisibilitiesCmd {
+	return &ListVisibilitiesCmd{Context: context}
+}
+
+//Run runs the command's logic
+func (lv *ListVisibilitiesCmd) Run() error {
+	visibilities, err := lv.Client.ListVisibilities()
+	if err != nil {
+		return err
+	}
+
+	output.PrintServiceManagerObject(lv.Output, lv.outputFormat, visibilities)
+	output.Println(lv.Output)
+	return nil
+}
+
+// SetOutputFormat sets output format
+func (lv *ListVisibilitiesCmd) SetOutputFormat(format output.Format) {
+	lv.outputFormat = format
+}
+
+// HideUsage hides command's usage
+func (lv *ListVisibilitiesCmd) HideUsage() bool {
+	return true
+}
+
+// Prepare returns cobra command
+func (lv *ListVisibilitiesCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		Use:     "list-visibilities",
+		Aliases: []string{"lv"},
+		Short:   "List visibilities",
+		Long:    "List all visibilities.",
+		PreRunE: prepare(lv, lv.Context),
+		RunE:    cmd.RunE(lv),
+	}
+
+	cmd.AddFormatFlag(result.Flags())
+
+	return result
+}

--- a/internal/cmd/visibility/list_visibilities.go
+++ b/internal/cmd/visibility/list_visibilities.go
@@ -19,6 +19,7 @@ package visibility
 import (
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/Peripli/service-manager-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +28,8 @@ type ListVisibilitiesCmd struct {
 	*cmd.Context
 
 	outputFormat output.Format
+	fieldQuery []string
+	labelQuery []string
 }
 
 // NewListVisibilitiesCmd returns new list-visibilities command with context
@@ -36,7 +39,9 @@ func NewListVisibilitiesCmd(context *cmd.Context) *ListVisibilitiesCmd {
 
 //Run runs the command's logic
 func (lv *ListVisibilitiesCmd) Run() error {
-	visibilities, err := lv.Client.ListVisibilities()
+	parsedFieldQuery := util.ParseQuery(lv.fieldQuery)
+	parsedLabelQuery := util.ParseQuery(lv.labelQuery)
+	visibilities, err := lv.Client.ListVisibilitiesWithQuery(parsedFieldQuery, parsedLabelQuery)
 	if err != nil {
 		return err
 	}
@@ -68,6 +73,7 @@ func (lv *ListVisibilitiesCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 	}
 
 	cmd.AddFormatFlag(result.Flags())
+	cmd.AddQueryingFlags(result.Flags(), &lv.fieldQuery, &lv.labelQuery)
 
 	return result
 }

--- a/internal/cmd/visibility/list_visibilities.go
+++ b/internal/cmd/visibility/list_visibilities.go
@@ -23,13 +23,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListVisibilityCmd wraps the smctl list-visibilities command
+// ListVisibilitiesCmd wraps the smctl list-visibilities command
 type ListVisibilitiesCmd struct {
 	*cmd.Context
 
 	outputFormat output.Format
-	fieldQuery []string
-	labelQuery []string
+	fieldQuery   []string
+	labelQuery   []string
 }
 
 // NewListVisibilitiesCmd returns new list-visibilities command with context

--- a/internal/cmd/visibility/list_visibilities_test.go
+++ b/internal/cmd/visibility/list_visibilities_test.go
@@ -1,47 +1,46 @@
-package platform
+package visibility
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
-	"testing"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	yaml "gopkg.in/yaml.v2"
-
-	"bytes"
-
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
 	"github.com/Peripli/service-manager-cli/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	"testing"
 )
 
-func TestListPlatformsCmd(t *testing.T) {
+func TestListVisibilitiesCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "")
 }
 
-var _ = Describe("List platforms command test", func() {
+var _ = Describe("List visibilities command test", func() {
 
 	var client *smclientfakes.FakeClient
-	var command *ListPlatformsCmd
+	var command *ListVisibilitiesCmd
 	var buffer *bytes.Buffer
-	platform := types.Platform{
-		Name: "platform1",
-		Type: "type1",
-		ID:   "id1",
+
+	visibility := types.Visibility{
+		ID:            "visibilityID",
+		PlatformID:    "platformID",
+		ServicePlanID: "planID",
 	}
-	platform2 := types.Platform{
-		Name: "platform2",
-		Type: "type2",
-		ID:   "id2",
+
+	visibility2 := types.Visibility{
+		ID:            "visibilityID2",
+		PlatformID:    "platformID2",
+		ServicePlanID: "planID2",
 	}
 
 	BeforeEach(func() {
 		buffer = &bytes.Buffer{}
 		client = &smclientfakes.FakeClient{}
 		context := &cmd.Context{Output: buffer, Client: client}
-		command = NewListPlatformsCmd(context)
+		command = NewListVisibilitiesCmd(context)
 	})
 
 	executeWithArgs := func(args []string) error {
@@ -51,29 +50,29 @@ var _ = Describe("List platforms command test", func() {
 		return commandToRun.Execute()
 	}
 
-	Context("when no platforms are registered", func() {
-		It("should list empty platforms", func() {
-			client.ListPlatformsWithQueryReturns(&types.Platforms{Platforms: []types.Platform{}}, nil)
+	Context("when no visibilities are registered", func() {
+		It("should list empty visibilities", func() {
+			client.ListVisibilitiesReturns(&types.Visibilities{Visibilities: []types.Visibility{}}, nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("No platforms registered"))
+			Expect(buffer.String()).To(ContainSubstring("No visibilities registered"))
 		})
 	})
 
-	Context("when platforms are registered", func() {
-		It("should list 1 platform", func() {
-			result := &types.Platforms{Platforms: []types.Platform{platform}}
-			client.ListPlatformsWithQueryReturns(result, nil)
+	Context("when visibilities are registered", func() {
+		It("should list 1 visibility", func() {
+			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
+			client.ListVisibilitiesReturns(result, nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring(result.TableData().String()))
 		})
 
-		It("should list more platforms", func() {
-			result := &types.Platforms{Platforms: []types.Platform{platform, platform2}}
-			client.ListPlatformsWithQueryReturns(result, nil)
+		It("should list more visibilities", func() {
+			result := &types.Visibilities{Visibilities: []types.Visibility{visibility, visibility2}}
+			client.ListVisibilitiesReturns(result, nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -82,36 +81,10 @@ var _ = Describe("List platforms command test", func() {
 		})
 	})
 
-	Context("when field query flag is used", func() {
-		It("should pass it to SM", func() {
-			result := &types.Platforms{Platforms: []types.Platform{platform}}
-			client.ListPlatformsWithQueryReturns(result, nil)
-			err := executeWithArgs([]string{"-f", "name = platform1"})
-
-			arg1, arg2 := client.ListPlatformsWithQueryArgsForCall(0)
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect([]string{arg1, arg2}).To(ConsistOf("name+%3D+platform1", ""))
-		})
-	})
-
-	Context("when label query flag is used", func() {
-		It("should pass it to SM", func() {
-			result := &types.Platforms{Platforms: []types.Platform{platform}}
-			client.ListPlatformsWithQueryReturns(result, nil)
-			err := executeWithArgs([]string{"-l", "test = false"})
-
-			arg1, arg2 := client.ListPlatformsWithQueryArgsForCall(0)
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect([]string{arg1, arg2}).To(ConsistOf("", "test+%3D+false"))
-		})
-	})
-
 	Context("when format flag is used", func() {
 		It("should print in json", func() {
-			result := &types.Platforms{Platforms: []types.Platform{platform}}
-			client.ListPlatformsWithQueryReturns(result, nil)
+			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
+			client.ListVisibilitiesReturns(result, nil)
 
 			err := executeWithArgs([]string{"-o", "json"})
 
@@ -122,8 +95,8 @@ var _ = Describe("List platforms command test", func() {
 		})
 
 		It("should print in yaml", func() {
-			result := &types.Platforms{Platforms: []types.Platform{platform}}
-			client.ListPlatformsWithQueryReturns(result, nil)
+			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
+			client.ListVisibilitiesReturns(result, nil)
 
 			err := executeWithArgs([]string{"-o", "yaml"})
 
@@ -152,7 +125,7 @@ var _ = Describe("List platforms command test", func() {
 	Context("when error is returned by Service manager", func() {
 		It("should handle error", func() {
 			expectedErr := errors.New("Http Client Error")
-			client.ListPlatformsWithQueryReturns(nil, expectedErr)
+			client.ListVisibilitiesReturns(nil, expectedErr)
 			err := executeWithArgs([]string{})
 
 			Expect(err).Should(HaveOccurred())

--- a/internal/cmd/visibility/list_visibilities_test.go
+++ b/internal/cmd/visibility/list_visibilities_test.go
@@ -52,7 +52,7 @@ var _ = Describe("List visibilities command test", func() {
 
 	Context("when no visibilities are registered", func() {
 		It("should list empty visibilities", func() {
-			client.ListVisibilitiesReturns(&types.Visibilities{Visibilities: []types.Visibility{}}, nil)
+			client.ListVisibilitiesWithQueryReturns(&types.Visibilities{Visibilities: []types.Visibility{}}, nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("List visibilities command test", func() {
 	Context("when visibilities are registered", func() {
 		It("should list 1 visibility", func() {
 			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
-			client.ListVisibilitiesReturns(result, nil)
+			client.ListVisibilitiesWithQueryReturns(result, nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -72,7 +72,7 @@ var _ = Describe("List visibilities command test", func() {
 
 		It("should list more visibilities", func() {
 			result := &types.Visibilities{Visibilities: []types.Visibility{visibility, visibility2}}
-			client.ListVisibilitiesReturns(result, nil)
+			client.ListVisibilitiesWithQueryReturns(result, nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -81,10 +81,36 @@ var _ = Describe("List visibilities command test", func() {
 		})
 	})
 
+	Context("when field query flag is used", func() {
+		It("should pass it to SM", func() {
+			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
+			client.ListVisibilitiesWithQueryReturns(result, nil)
+			err := executeWithArgs([]string{"-f", "planId = plan1"})
+
+			arg1, arg2 := client.ListVisibilitiesWithQueryArgsForCall(0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect([]string{arg1, arg2}).To(ConsistOf("planId+%3D+plan1", ""))
+		})
+	})
+
+	Context("when label query flag is used", func() {
+		It("should pass it to SM", func() {
+			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
+			client.ListVisibilitiesWithQueryReturns(result, nil)
+			err := executeWithArgs([]string{"-l", "test = false"})
+
+			arg1, arg2 := client.ListVisibilitiesWithQueryArgsForCall(0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect([]string{arg1, arg2}).To(ConsistOf("", "test+%3D+false"))
+		})
+	})
+
 	Context("when format flag is used", func() {
 		It("should print in json", func() {
 			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
-			client.ListVisibilitiesReturns(result, nil)
+			client.ListVisibilitiesWithQueryReturns(result, nil)
 
 			err := executeWithArgs([]string{"-o", "json"})
 
@@ -96,7 +122,7 @@ var _ = Describe("List visibilities command test", func() {
 
 		It("should print in yaml", func() {
 			result := &types.Visibilities{Visibilities: []types.Visibility{visibility}}
-			client.ListVisibilitiesReturns(result, nil)
+			client.ListVisibilitiesWithQueryReturns(result, nil)
 
 			err := executeWithArgs([]string{"-o", "yaml"})
 
@@ -125,7 +151,7 @@ var _ = Describe("List visibilities command test", func() {
 	Context("when error is returned by Service manager", func() {
 		It("should handle error", func() {
 			expectedErr := errors.New("Http Client Error")
-			client.ListVisibilitiesReturns(nil, expectedErr)
+			client.ListVisibilitiesWithQueryReturns(nil, expectedErr)
 			err := executeWithArgs([]string{})
 
 			Expect(err).Should(HaveOccurred())

--- a/internal/cmd/visibility/register_visibility.go
+++ b/internal/cmd/visibility/register_visibility.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package visibility
+
+import (
+	"fmt"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// RegisterVisibilityCmd wraps the smctl register-visibility command
+type RegisterVisibilityCmd struct {
+	*cmd.Context
+
+	visibility types.Visibility
+
+	outputFormat output.Format
+}
+
+// NewRegisterVisibility returns new smctl register-visibility command with context
+func NewRegisterVisibilityCmd(ctx *cmd.Context) *RegisterVisibilityCmd {
+	return &RegisterVisibilityCmd{Context: ctx}
+}
+
+// Validate validates command's arguments
+func (rv *RegisterVisibilityCmd) Validate(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("platform-id and service-plan-id required but not provided")
+	}
+	rv.visibility.PlatformID = args[0]
+	rv.visibility.ServicePlanID = args[1]
+	return nil
+}
+
+// Run runs command's logic
+func (rv *RegisterVisibilityCmd) Run() error {
+	resultVisibility, err := rv.Client.RegisterVisibility(&rv.visibility)
+	if err != nil {
+		return err
+	}
+	output.PrintServiceManagerObject(rv.Output, rv.outputFormat, resultVisibility)
+	output.Println(rv.Output)
+	return nil
+}
+
+// SetOutputFormat sets command's output format
+func (rv *RegisterVisibilityCmd) SetOutputFormat(format output.Format) {
+	rv.outputFormat = format
+}
+
+// HideUsage hide command's usage
+func (rv *RegisterVisibilityCmd) HideUsage() bool {
+	return true
+}
+
+// Prepare returns cobra command
+func (rv *RegisterVisibilityCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		Use:     "register-visibility [platform id] [service plan id]",
+		Aliases: []string{"rv"},
+		Short:   "Registers a visibility",
+		Long:    "Registers a visibility",
+
+		PreRunE: prepare(rv, rv.Context),
+		RunE:    cmd.RunE(rv),
+	}
+
+	result.Flags().StringVarP(&rv.visibility.ID, "id", "i", "", "external visibility ID")
+	cmd.AddFormatFlag(result.Flags())
+
+	return result
+}

--- a/internal/cmd/visibility/register_visibility.go
+++ b/internal/cmd/visibility/register_visibility.go
@@ -33,7 +33,7 @@ type RegisterVisibilityCmd struct {
 	outputFormat output.Format
 }
 
-// NewRegisterVisibility returns new smctl register-visibility command with context
+// NewRegisterVisibilityCmd returns new smctl register-visibility command with context
 func NewRegisterVisibilityCmd(ctx *cmd.Context) *RegisterVisibilityCmd {
 	return &RegisterVisibilityCmd{Context: ctx}
 }

--- a/internal/cmd/visibility/register_visibility.go
+++ b/internal/cmd/visibility/register_visibility.go
@@ -81,7 +81,6 @@ func (rv *RegisterVisibilityCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command
 		RunE:    cmd.RunE(rv),
 	}
 
-	result.Flags().StringVarP(&rv.visibility.ID, "id", "i", "", "external visibility ID")
 	cmd.AddFormatFlag(result.Flags())
 
 	return result

--- a/internal/cmd/visibility/register_visibility_test.go
+++ b/internal/cmd/visibility/register_visibility_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Register visibility command test", func() {
 		command = NewRegisterVisibilityCmd(context)
 	})
 
-	validRegisterVisibilityExecution := func(args... string) error {
+	validRegisterVisibilityExecution := func(args ...string) error {
 		visibility = &types.Visibility{
 			ID:            "visibilityID",
 			PlatformID:    args[0],
@@ -44,7 +44,7 @@ var _ = Describe("Register visibility command test", func() {
 		return rvCmd.Execute()
 	}
 
-	invalidRegisterVisibilityExecution := func(args... string) error {
+	invalidRegisterVisibilityExecution := func(args ...string) error {
 		rvCmd := command.Prepare(cmd.SmPrepare)
 		rvCmd.SetArgs(args)
 		return rvCmd.Execute()

--- a/internal/cmd/visibility/register_visibility_test.go
+++ b/internal/cmd/visibility/register_visibility_test.go
@@ -71,18 +71,6 @@ var _ = Describe("Register visibility command test", func() {
 			})
 		})
 
-		Context("With id flag provided", func() {
-			It("visibility id should be as expected", func() {
-				args := []string{"platformId", "planId", "--id", "id"}
-
-				err := validRegisterVisibilityExecution(args...)
-				v := client.RegisterVisibilityArgsForCall(0)
-
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(v.ID).To(Equal("id"))
-			})
-		})
-
 		Context("With json format flag", func() {
 			It("should be printed in json format", func() {
 				err := validRegisterVisibilityExecution("platformId", "planId", "--output", "json")

--- a/internal/cmd/visibility/register_visibility_test.go
+++ b/internal/cmd/visibility/register_visibility_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Register visibility command test", func() {
 		command = NewRegisterVisibilityCmd(context)
 	})
 
-	validRegisterVisibilityExecution := func(args []string) error {
+	validRegisterVisibilityExecution := func(args... string) error {
 		visibility = &types.Visibility{
 			ID:            "visibilityID",
 			PlatformID:    args[0],
@@ -44,7 +44,7 @@ var _ = Describe("Register visibility command test", func() {
 		return rvCmd.Execute()
 	}
 
-	invalidRegisterVisibilityExecution := func(args []string) error {
+	invalidRegisterVisibilityExecution := func(args... string) error {
 		rvCmd := command.Prepare(cmd.SmPrepare)
 		rvCmd.SetArgs(args)
 		return rvCmd.Execute()
@@ -53,7 +53,7 @@ var _ = Describe("Register visibility command test", func() {
 	Describe("Valid request", func() {
 		Context("With necessary arguments provided", func() {
 			It("visibility should be registered", func() {
-				err := validRegisterVisibilityExecution([]string{"platformId", "planId"})
+				err := validRegisterVisibilityExecution("platformId", "planId")
 				tableOutputExpected := visibility.TableData().String()
 
 				Expect(err).ShouldNot(HaveOccurred())
@@ -61,7 +61,7 @@ var _ = Describe("Register visibility command test", func() {
 			})
 
 			It("argument values should be as expected", func() {
-				err := validRegisterVisibilityExecution([]string{"platformId", "planId"})
+				err := validRegisterVisibilityExecution("platformId", "planId")
 
 				v := client.RegisterVisibilityArgsForCall(0)
 
@@ -75,7 +75,7 @@ var _ = Describe("Register visibility command test", func() {
 			It("visibility id should be as expected", func() {
 				args := []string{"platformId", "planId", "--id", "id"}
 
-				err := validRegisterVisibilityExecution(args)
+				err := validRegisterVisibilityExecution(args...)
 				v := client.RegisterVisibilityArgsForCall(0)
 
 				Expect(err).ShouldNot(HaveOccurred())
@@ -85,7 +85,7 @@ var _ = Describe("Register visibility command test", func() {
 
 		Context("With json format flag", func() {
 			It("should be printed in json format", func() {
-				err := validRegisterVisibilityExecution([]string{"platformId", "planId", "--output", "json"})
+				err := validRegisterVisibilityExecution("platformId", "planId", "--output", "json")
 
 				jsonByte, _ := json.MarshalIndent(visibility, "", "  ")
 				jsonOutputExpected := string(jsonByte) + "\n"
@@ -97,7 +97,7 @@ var _ = Describe("Register visibility command test", func() {
 
 		Context("With yaml format flag", func() {
 			It("should be printed in yaml format", func() {
-				err := validRegisterVisibilityExecution([]string{"platformId", "planId", "--output", "yaml"})
+				err := validRegisterVisibilityExecution("platformId", "planId", "--output", "yaml")
 
 				yamlByte, _ := yaml.Marshal(visibility)
 				yamlOutputExpected := string(yamlByte) + "\n"
@@ -111,7 +111,7 @@ var _ = Describe("Register visibility command test", func() {
 	Describe("Invalid request", func() {
 		Context("With not enough arguments provided", func() {
 			It("Should return error", func() {
-				err := invalidRegisterVisibilityExecution([]string{"platformId"})
+				err := invalidRegisterVisibilityExecution("platformId")
 
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("platform-id and service-plan-id required but not provided"))
@@ -123,7 +123,7 @@ var _ = Describe("Register visibility command test", func() {
 				expectedErr := errors.New("http client error")
 				client.RegisterVisibilityReturns(nil, expectedErr)
 
-				err := invalidRegisterVisibilityExecution([]string{"platformId", "planId"})
+				err := invalidRegisterVisibilityExecution("platformId", "planId")
 
 				Expect(err).Should(HaveOccurred())
 				Expect(err).To(MatchError(expectedErr.Error()))
@@ -133,7 +133,7 @@ var _ = Describe("Register visibility command test", func() {
 		Context("With invalid output format", func() {
 			It("should return error", func() {
 				invFormat := "invalid-format"
-				err := invalidRegisterVisibilityExecution([]string{"platformId", "planId", "--output", invFormat})
+				err := invalidRegisterVisibilityExecution("platformId", "planId", "--output", invFormat)
 
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).To(Equal("unknown output: " + invFormat))

--- a/internal/cmd/visibility/register_visibility_test.go
+++ b/internal/cmd/visibility/register_visibility_test.go
@@ -1,0 +1,143 @@
+package visibility
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestRegisterVisibilityCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("Register visibility command test", func() {
+
+	var client *smclientfakes.FakeClient
+	var command *RegisterVisibilityCmd
+	var buffer *bytes.Buffer
+	var visibility *types.Visibility
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		client = &smclientfakes.FakeClient{}
+		context := &cmd.Context{Output: buffer, Client: client}
+		command = NewRegisterVisibilityCmd(context)
+	})
+
+	validRegisterVisibilityExecution := func(args []string) error {
+		visibility = &types.Visibility{
+			ID:            "visibilityID",
+			PlatformID:    args[0],
+			ServicePlanID: args[1],
+		}
+		client.RegisterVisibilityReturns(visibility, nil)
+		rvCmd := command.Prepare(cmd.SmPrepare)
+		rvCmd.SetArgs(args)
+		return rvCmd.Execute()
+	}
+
+	invalidRegisterVisibilityExecution := func(args []string) error {
+		rvCmd := command.Prepare(cmd.SmPrepare)
+		rvCmd.SetArgs(args)
+		return rvCmd.Execute()
+	}
+
+	Describe("Valid request", func() {
+		Context("With necessary arguments provided", func() {
+			It("visibility should be registered", func() {
+				err := validRegisterVisibilityExecution([]string{"platformId", "planId"})
+				tableOutputExpected := visibility.TableData().String()
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring(tableOutputExpected))
+			})
+
+			It("argument values should be as expected", func() {
+				err := validRegisterVisibilityExecution([]string{"platformId", "planId"})
+
+				v := client.RegisterVisibilityArgsForCall(0)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(v.PlatformID).To(Equal("platformId"))
+				Expect(v.ServicePlanID).To(Equal("planId"))
+			})
+		})
+
+		Context("With id flag provided", func() {
+			It("visibility id should be as expected", func() {
+				args := []string{"platformId", "planId", "--id", "id"}
+
+				err := validRegisterVisibilityExecution(args)
+				v := client.RegisterVisibilityArgsForCall(0)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(v.ID).To(Equal("id"))
+			})
+		})
+
+		Context("With json format flag", func() {
+			It("should be printed in json format", func() {
+				err := validRegisterVisibilityExecution([]string{"platformId", "planId", "--output", "json"})
+
+				jsonByte, _ := json.MarshalIndent(visibility, "", "  ")
+				jsonOutputExpected := string(jsonByte) + "\n"
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(Equal(jsonOutputExpected))
+			})
+		})
+
+		Context("With yaml format flag", func() {
+			It("should be printed in yaml format", func() {
+				err := validRegisterVisibilityExecution([]string{"platformId", "planId", "--output", "yaml"})
+
+				yamlByte, _ := yaml.Marshal(visibility)
+				yamlOutputExpected := string(yamlByte) + "\n"
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(Equal(yamlOutputExpected))
+			})
+		})
+	})
+
+	Describe("Invalid request", func() {
+		Context("With not enough arguments provided", func() {
+			It("Should return error", func() {
+				err := invalidRegisterVisibilityExecution([]string{"platformId"})
+
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("platform-id and service-plan-id required but not provided"))
+			})
+		})
+
+		Context("With error from http client", func() {
+			It("Should return error", func() {
+				expectedErr := errors.New("http client error")
+				client.RegisterVisibilityReturns(nil, expectedErr)
+
+				err := invalidRegisterVisibilityExecution([]string{"platformId", "planId"})
+
+				Expect(err).Should(HaveOccurred())
+				Expect(err).To(MatchError(expectedErr.Error()))
+			})
+		})
+
+		Context("With invalid output format", func() {
+			It("should return error", func() {
+				invFormat := "invalid-format"
+				err := invalidRegisterVisibilityExecution([]string{"platformId", "planId", "--output", invFormat})
+
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(Equal("unknown output: " + invFormat))
+			})
+		})
+	})
+})

--- a/internal/cmd/visibility/update_visibility.go
+++ b/internal/cmd/visibility/update_visibility.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package visibility
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// UpdateVisibilityCmd wraps smctl update-visibility command
+type UpdateVisibilityCmd struct {
+	*cmd.Context
+
+	outputFormat      output.Format
+	id                string
+	updatedVisibility *types.Visibility
+}
+
+// NewUpdateVisibilityCmd returns new smctl update-visibility command with context
+func NewUpdateVisibilityCmd(context *cmd.Context) *UpdateVisibilityCmd {
+	return &UpdateVisibilityCmd{Context: context}
+}
+
+// Validate validates command's arguments
+func (uv *UpdateVisibilityCmd) Validate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("id is required")
+	}
+
+	uv.id = args[0]
+
+	if len(args) < 2 {
+		return fmt.Errorf("nothing to update. Visibility JSON is not provided")
+	}
+
+	if err := json.Unmarshal([]byte(args[1]), &uv.updatedVisibility); err != nil {
+		return fmt.Errorf("visibility JSON is invalid. Reason: %s", err.Error())
+	}
+
+	return nil
+}
+
+// Run runs the command's logic
+func (uv *UpdateVisibilityCmd) Run() error {
+	updatedVisibility, err := uv.Client.UpdateVisibility(uv.id, uv.updatedVisibility)
+	if err != nil {
+		return err
+	}
+	output.PrintServiceManagerObject(uv.Output, uv.outputFormat, updatedVisibility)
+	output.Println(uv.Output)
+	return nil
+}
+
+// HideUsage hide command's usage
+func (uv *UpdateVisibilityCmd) HideUsage() bool {
+	return true
+}
+
+// SetOutputFormat set output format
+func (uv *UpdateVisibilityCmd) SetOutputFormat(format output.Format) {
+	uv.outputFormat = format
+}
+
+//Prepare returns cobra command
+func (uv *UpdateVisibilityCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		Use:     "update-visibility [id] <json-visibility>",
+		Aliases: []string{"uv"},
+		Short:   "Updates visibility",
+		Long:    "Updates visibility by id.",
+		PreRunE: prepare(uv, uv.Context),
+		RunE:    cmd.RunE(uv),
+	}
+
+	cmd.AddFormatFlag(result.Flags())
+
+	return result
+}

--- a/internal/cmd/visibility/update_visibility_test.go
+++ b/internal/cmd/visibility/update_visibility_test.go
@@ -1,0 +1,138 @@
+package visibility
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestUpdateVisibilityCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("Update visibility command test", func() {
+
+	var client *smclientfakes.FakeClient
+	var command *UpdateVisibilityCmd
+	var buffer *bytes.Buffer
+	var visibility *types.Visibility
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		client = &smclientfakes.FakeClient{}
+		context := &cmd.Context{Output: buffer, Client: client}
+		command = NewUpdateVisibilityCmd(context)
+	})
+
+	validUpdateVisibilityExecution := func(args... string) error {
+		visibility = &types.Visibility{
+			ID:            "visibilityID",
+			PlatformID:    "platformID",
+			ServicePlanID: "planID",
+		}
+		json.Unmarshal([]byte(args[1]), visibility)
+		client.UpdateVisibilityReturns(visibility, nil)
+		uvCmd := command.Prepare(cmd.SmPrepare)
+		uvCmd.SetArgs(args)
+		return uvCmd.Execute()
+	}
+
+	invalidUpdateVisibilityExecution := func(args... string) error {
+		uvCmd := command.Prepare(cmd.SmPrepare)
+		uvCmd.SetArgs(args)
+		return uvCmd.Execute()
+	}
+
+	Describe("Valid request", func() {
+		Context("With necessary arguments provided", func() {
+			It("visibility should be updated", func() {
+
+				err := validUpdateVisibilityExecution("id", `{"platform_id":"newPlatformID"}`)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring(visibility.TableData().String()))
+			})
+
+			It("argument values should be as expected", func() {
+				err := validUpdateVisibilityExecution("id", `{"platform_id":"newPlatformID"}`)
+
+				id, v := client.UpdateVisibilityArgsForCall(0)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(id).To(Equal("id"))
+				Expect(v).To(Equal(&types.Visibility{PlatformID: "newPlatformID"}))
+			})
+		})
+
+		Context("With json format flag", func() {
+			It("should be printed in json format", func() {
+				err := validUpdateVisibilityExecution("id", `{"platform_id":"newPlatformID"}`, "--output", "json")
+
+				jsonByte, _ := json.MarshalIndent(visibility, "", "  ")
+				jsonOutputExpected := string(jsonByte) + "\n"
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(Equal(jsonOutputExpected))
+			})
+		})
+
+		Context("With yaml format flag", func() {
+			It("should be printed in yaml format", func() {
+				err := validUpdateVisibilityExecution("platformId", `{"platform_id":"newPlatformID"}`, "--output", "yaml")
+
+				yamlByte, _ := yaml.Marshal(visibility)
+				yamlOutputExpected := string(yamlByte) + "\n"
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(Equal(yamlOutputExpected))
+			})
+		})
+	})
+
+	Describe("Invalid request", func() {
+		Context("With missing arguments", func() {
+			It("Should return error missing id", func() {
+				err := invalidUpdateVisibilityExecution()
+
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("id is required"))
+			})
+			It("Should return error missing json", func() {
+				err := invalidUpdateVisibilityExecution("id")
+
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("nothing to update. Visibility JSON is not provided"))
+			})
+		})
+	})
+
+	Context("With error from http client", func() {
+		It("Should return error", func() {
+			expectedErr := errors.New("http client error")
+			client.UpdateVisibilityReturns(nil, expectedErr)
+
+			err := invalidUpdateVisibilityExecution("id",`{"platform_id":"newPlatformID"}`)
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError(expectedErr.Error()))
+		})
+	})
+
+	Context("With invalid output format", func() {
+		It("should return error", func() {
+			invFormat := "invalid-format"
+			err := invalidUpdateVisibilityExecution("id",`{"platform_id":"newPlatformID"}`, "--output", invFormat)
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown output: " + invFormat))
+		})
+	})
+})

--- a/internal/cmd/visibility/update_visibility_test.go
+++ b/internal/cmd/visibility/update_visibility_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Update visibility command test", func() {
 		command = NewUpdateVisibilityCmd(context)
 	})
 
-	validUpdateVisibilityExecution := func(args... string) error {
+	validUpdateVisibilityExecution := func(args ...string) error {
 		visibility = &types.Visibility{
 			ID:            "visibilityID",
 			PlatformID:    "platformID",
@@ -45,7 +45,7 @@ var _ = Describe("Update visibility command test", func() {
 		return uvCmd.Execute()
 	}
 
-	invalidUpdateVisibilityExecution := func(args... string) error {
+	invalidUpdateVisibilityExecution := func(args ...string) error {
 		uvCmd := command.Prepare(cmd.SmPrepare)
 		uvCmd.SetArgs(args)
 		return uvCmd.Execute()
@@ -119,7 +119,7 @@ var _ = Describe("Update visibility command test", func() {
 			expectedErr := errors.New("http client error")
 			client.UpdateVisibilityReturns(nil, expectedErr)
 
-			err := invalidUpdateVisibilityExecution("id",`{"platform_id":"newPlatformID"}`)
+			err := invalidUpdateVisibilityExecution("id", `{"platform_id":"newPlatformID"}`)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err).To(MatchError(expectedErr.Error()))
@@ -129,7 +129,7 @@ var _ = Describe("Update visibility command test", func() {
 	Context("With invalid output format", func() {
 		It("should return error", func() {
 			invFormat := "invalid-format"
-			err := invalidUpdateVisibilityExecution("id",`{"platform_id":"newPlatformID"}`, "--output", invFormat)
+			err := invalidUpdateVisibilityExecution("id", `{"platform_id":"newPlatformID"}`, "--output", invFormat)
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown output: " + invFormat))

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Peripli/service-manager-cli/internal/cmd/offering"
 	"github.com/Peripli/service-manager-cli/internal/cmd/platform"
 	"github.com/Peripli/service-manager-cli/internal/cmd/version"
+	"github.com/Peripli/service-manager-cli/internal/cmd/visibility"
 	"github.com/Peripli/service-manager-cli/pkg/auth"
 	"github.com/Peripli/service-manager-cli/pkg/auth/oidc"
 	"github.com/spf13/afero"
@@ -64,6 +65,8 @@ func main() {
 			platform.NewListPlatformsCmd(context),
 			platform.NewDeletePlatformCmd(context, os.Stdin),
 			platform.NewUpdatePlatformCmd(context),
+			visibility.NewRegisterVisibilityCmd(context),
+			visibility.NewListVisibilitiesCmd(context),
 			offering.NewListOfferingsCmd(context),
 		},
 		PrepareFn: cmd.SmPrepare,

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 			platform.NewUpdatePlatformCmd(context),
 			visibility.NewRegisterVisibilityCmd(context),
 			visibility.NewListVisibilitiesCmd(context),
+			visibility.NewUpdateVisibilityCmd(context),
 			offering.NewListOfferingsCmd(context),
 		},
 		PrepareFn: cmd.SmPrepare,

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 			visibility.NewRegisterVisibilityCmd(context),
 			visibility.NewListVisibilitiesCmd(context),
 			visibility.NewUpdateVisibilityCmd(context),
+			visibility.NewDeleteVisibilityCmd(context, os.Stdin),
 			offering.NewListOfferingsCmd(context),
 		},
 		PrepareFn: cmd.SmPrepare,

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -37,13 +37,14 @@ type Client interface {
 	GetInfo() (*types.Info, error)
 	RegisterPlatform(*types.Platform) (*types.Platform, error)
 	RegisterBroker(*types.Broker) (*types.Broker, error)
-	ListBrokersWithQuery(string, string) (*types.Brokers, error)
 	RegisterVisibility(*types.Visibility) (*types.Visibility, error)
+	ListBrokersWithQuery(string, string) (*types.Brokers, error)
 	ListBrokers() (*types.Brokers, error)
 	ListPlatformsWithQuery(string, string) (*types.Platforms, error)
 	ListPlatforms() (*types.Platforms, error)
 	ListOfferingsWithQuery(string, string) (*types.ServiceOfferings, error)
 	ListOfferings() (*types.ServiceOfferings, error)
+	ListVisibilitiesWithQuery(string, string) (*types.Visibilities, error)
 	ListVisibilities() (*types.Visibilities, error)
 	DeleteBroker(string) error
 	DeletePlatform(string) error
@@ -195,12 +196,16 @@ func (client *serviceManagerClient) ListPlatforms() (*types.Platforms, error) {
 	return client.ListPlatformsWithQuery("", "")
 }
 
-// ListVisibilities returns visibilities registered in the Service Manager
-func (client *serviceManagerClient) ListVisibilities() (*types.Visibilities, error) {
+func (client *serviceManagerClient) ListVisibilitiesWithQuery(fieldQuery string, labelQuery string) (*types.Visibilities, error) {
 	visibilities := &types.Visibilities{}
-	err := client.list(visibilities, web.VisibilitiesURL)
+	err := client.list(visibilities, web.VisibilitiesURL+"?fieldQuery="+fieldQuery+"&labelQuery="+labelQuery)
 
 	return visibilities, err
+}
+
+// ListVisibilities returns visibilities registered in the Service Manager
+func (client *serviceManagerClient) ListVisibilities() (*types.Visibilities, error) {
+	return client.ListVisibilitiesWithQuery("", "")
 }
 
 // ListOfferings returns service offerings satisfying provided queries

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -38,15 +38,19 @@ type Client interface {
 	RegisterPlatform(*types.Platform) (*types.Platform, error)
 	RegisterBroker(*types.Broker) (*types.Broker, error)
 	ListBrokersWithQuery(string, string) (*types.Brokers, error)
+	RegisterVisibility(*types.Visibility) (*types.Visibility, error)
 	ListBrokers() (*types.Brokers, error)
 	ListPlatformsWithQuery(string, string) (*types.Platforms, error)
 	ListPlatforms() (*types.Platforms, error)
 	ListOfferingsWithQuery(string, string) (*types.ServiceOfferings, error)
 	ListOfferings() (*types.ServiceOfferings, error)
+	ListVisibilities() (*types.Visibilities, error)
 	DeleteBroker(string) error
 	DeletePlatform(string) error
+	DeleteVisibility(string) error
 	UpdateBroker(string, *types.Broker) (*types.Broker, error)
 	UpdatePlatform(string, *types.Platform) (*types.Platform, error)
+	UpdateVisibility(string, *types.Visibility) (*types.Visibility, error)
 
 	// Call makes HTTP request to the Service Manager server with authentication.
 	// It should be used only in case there is no already implemented method for such an operation
@@ -118,54 +122,51 @@ func (client *serviceManagerClient) GetInfo() (*types.Info, error) {
 
 // RegisterPlatform registers a platform in the service manager
 func (client *serviceManagerClient) RegisterPlatform(platform *types.Platform) (*types.Platform, error) {
-	requestBody, err := json.Marshal(platform)
-	if err != nil {
-		return nil, err
-	}
-
-	buffer := bytes.NewBuffer(requestBody)
-	response, err := client.Call(http.MethodPost, web.PlatformsURL, buffer)
-	if err != nil {
-		return nil, err
-	}
-
-	if response.StatusCode != http.StatusCreated {
-		return nil, errors.ResponseError{StatusCode: response.StatusCode}
-	}
-
 	var newPlatform *types.Platform
-	err = httputil.UnmarshalResponse(response, &newPlatform)
+	err := client.register(platform, web.PlatformsURL, &newPlatform)
 	if err != nil {
 		return nil, err
 	}
-
 	return newPlatform, nil
 }
 
 // RegisterBroker registers a broker in the service manager
 func (client *serviceManagerClient) RegisterBroker(broker *types.Broker) (*types.Broker, error) {
-	requestBody, err := json.Marshal(broker)
+	var newBroker *types.Broker
+	err := client.register(broker, web.ServiceBrokersURL, &newBroker)
 	if err != nil {
 		return nil, err
+	}
+	return newBroker, nil
+}
+
+// RegisterVisibility registers a visibility in the service manager
+func (client *serviceManagerClient) RegisterVisibility(visibility *types.Visibility) (*types.Visibility, error) {
+	var newVisibility *types.Visibility
+	err := client.register(visibility, web.VisibilitiesURL, &newVisibility)
+	if err != nil {
+		return nil, err
+	}
+	return newVisibility, nil
+}
+
+func (client *serviceManagerClient) register(resource interface{}, url string, result interface{}) error {
+	requestBody, err := json.Marshal(resource)
+	if err != nil {
+		return err
 	}
 
 	buffer := bytes.NewBuffer(requestBody)
-	response, err := client.Call(http.MethodPost, web.ServiceBrokersURL, buffer)
+	response, err := client.Call(http.MethodPost, url, buffer)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if response.StatusCode != http.StatusCreated {
-		return nil, errors.ResponseError{StatusCode: response.StatusCode}
+		return errors.ResponseError{StatusCode: response.StatusCode}
 	}
 
-	var newBroker *types.Broker
-	err = httputil.UnmarshalResponse(response, &newBroker)
-	if err != nil {
-		return nil, err
-	}
-
-	return newBroker, nil
+	return httputil.UnmarshalResponse(response, &result)
 }
 
 // ListBrokersWithQuery returns brokers registered in the Service Manager satisfying provided queries
@@ -192,6 +193,14 @@ func (client *serviceManagerClient) ListPlatformsWithQuery(fieldQuery string, la
 // ListPlatforms returns platforms registered in the Service Manager
 func (client *serviceManagerClient) ListPlatforms() (*types.Platforms, error) {
 	return client.ListPlatformsWithQuery("", "")
+}
+
+// ListVisibilities returns visibilities registered in the Service Manager
+func (client *serviceManagerClient) ListVisibilities() (*types.Visibilities, error) {
+	visibilities := &types.Visibilities{}
+	err := client.list(visibilities, web.VisibilitiesURL)
+
+	return visibilities, err
 }
 
 // ListOfferings returns service offerings satisfying provided queries
@@ -238,12 +247,19 @@ func (client *serviceManagerClient) list(result interface{}, path string) error 
 	return httputil.UnmarshalResponse(resp, &result)
 }
 
+// DeleteBroker deletes a broker with given id from service manager
 func (client *serviceManagerClient) DeleteBroker(id string) error {
 	return client.delete(id, web.ServiceBrokersURL)
 }
 
+// DeletePlatform deletes a platform with given id from service manager
 func (client *serviceManagerClient) DeletePlatform(id string) error {
 	return client.delete(id, web.PlatformsURL)
+}
+
+// DeleteVisibility deletes a visibility with given id from service manager
+func (client *serviceManagerClient) DeleteVisibility(id string) error {
+	return client.delete(id, web.VisibilitiesURL)
 }
 
 func (client *serviceManagerClient) delete(id, path string) error {
@@ -260,27 +276,39 @@ func (client *serviceManagerClient) delete(id, path string) error {
 }
 
 func (client *serviceManagerClient) UpdateBroker(id string, updatedBroker *types.Broker) (*types.Broker, error) {
-	requestBody, err := json.Marshal(updatedBroker)
+	result := &types.Broker{}
+	err := client.update(updatedBroker, web.ServiceBrokersURL, id, &result)
 	if err != nil {
 		return nil, err
 	}
-
-	result := &types.Broker{}
-	return result, client.update(result, requestBody, id, web.ServiceBrokersURL)
+	return result, nil
 }
 
 func (client *serviceManagerClient) UpdatePlatform(id string, updatedPlatform *types.Platform) (*types.Platform, error) {
-	requestBody, err := json.Marshal(updatedPlatform)
+	result := &types.Platform{}
+	err := client.update(updatedPlatform, web.PlatformsURL, id, &result)
 	if err != nil {
 		return nil, err
 	}
-	result := &types.Platform{}
-	return result, client.update(result, requestBody, id, web.PlatformsURL)
+	return result, nil
 }
 
-func (client *serviceManagerClient) update(result interface{}, body []byte, id, path string) error {
-	buffer := bytes.NewBuffer(body)
-	resp, err := client.Call(http.MethodPatch, path+"/"+id, buffer)
+func (client *serviceManagerClient) UpdateVisibility(id string, updatedVisibility *types.Visibility) (*types.Visibility, error) {
+	result := &types.Visibility{}
+	err := client.update(updatedVisibility, web.VisibilitiesURL, id, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (client *serviceManagerClient) update(resource interface{}, url string, id string, result interface{}) error {
+	requestBody, err := json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+	buffer := bytes.NewBuffer(requestBody)
+	resp, err := client.Call(http.MethodPatch, url+"/"+id, buffer)
 	if err != nil {
 		return err
 	}

--- a/pkg/smclient/client_test.go
+++ b/pkg/smclient/client_test.go
@@ -597,7 +597,7 @@ var _ = Describe("Service Manager Client test", func() {
 			It("should handle status code > 299", func() {
 				_, err := client.ListVisibilities()
 				Expect(err).Should(HaveOccurred())
-				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.VisibilitiesURL+"?fieldQuery=&labelQuery="}))
+				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.VisibilitiesURL + "?fieldQuery=&labelQuery="}))
 			})
 		})
 	})

--- a/pkg/smclient/client_test.go
+++ b/pkg/smclient/client_test.go
@@ -597,7 +597,7 @@ var _ = Describe("Service Manager Client test", func() {
 			It("should handle status code > 299", func() {
 				_, err := client.ListVisibilities()
 				Expect(err).Should(HaveOccurred())
-				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.VisibilitiesURL}))
+				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.VisibilitiesURL+"?fieldQuery=&labelQuery="}))
 			})
 		})
 	})

--- a/pkg/smclient/client_test.go
+++ b/pkg/smclient/client_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Service Manager Client test", func() {
 	var smServer *httptest.Server
 
 	platform := &types.Platform{
-		ID:          "1234",
+		ID:          "platformID",
 		Name:        "cfeu10",
 		Type:        "cf",
 		Description: "Test platform",
@@ -75,6 +75,12 @@ var _ = Describe("Service Manager Client test", func() {
 		Plans:       []types.ServicePlan{*plan},
 		BrokerID:    "id",
 		BrokerName:  "test-broker",
+	}
+
+	visibility := &types.Visibility{
+		ID:            "visibilityID",
+		PlatformID:    "platformID",
+		ServicePlanID: "planID",
 	}
 
 	createSMHandler := func() http.Handler {
@@ -210,6 +216,103 @@ var _ = Describe("Service Manager Client test", func() {
 			It("should return error", func() {
 				client = NewClient(http.DefaultClient, "invalidURL")
 				_, err := client.RegisterPlatform(platform)
+
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Register Visibility", func() {
+		Context("When valid visibility is being registered", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(visibility)
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPost, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+			It("should register successfully", func() {
+				responseVisibility, err := client.RegisterVisibility(visibility)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(responseVisibility).To(Equal(visibility))
+			})
+		})
+
+		Context("When invalid visibility is returned by SM", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(struct {
+					ID bool `json:"id"`
+				}{
+					ID: true,
+				})
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPost, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+
+			It("should return error", func() {
+				responseVisibility, err := client.RegisterVisibility(visibility)
+
+				Expect(err).Should(HaveOccurred())
+				Expect(responseVisibility).To(BeNil())
+			})
+		})
+
+		Context("When invalid status code is returned by SM", func() {
+			Context("And status code is successful", func() {
+				BeforeEach(func() {
+					responseBody, _ := json.Marshal(visibility)
+					handlerDetails = []HandlerDetails{
+						{Method: http.MethodPost, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+					}
+				})
+				It("should return error with status code", func() {
+					responseVisibility, err := client.RegisterVisibility(visibility)
+
+					Expect(err).Should(HaveOccurred())
+					Expect(err).To(MatchError(errors.ResponseError{StatusCode: handlerDetails[0].ResponseStatusCode}))
+					Expect(responseVisibility).To(BeNil())
+				})
+			})
+
+			Context("And status code is unsuccessful", func() {
+				BeforeEach(func() {
+					responseBody := []byte(`{ "description": "error"}`)
+					handlerDetails = []HandlerDetails{
+						{Method: http.MethodPost, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+					}
+				})
+				It("should return error with url and description", func() {
+					responseVisibility, err := client.RegisterVisibility(visibility)
+
+					Expect(err).Should(HaveOccurred())
+					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.VisibilitiesURL, Description: "error", StatusCode: handlerDetails[0].ResponseStatusCode}))
+					Expect(responseVisibility).To(BeNil())
+				})
+			})
+
+			Context("And response body is invalid", func() {
+				BeforeEach(func() {
+					responseBody := []byte(`{ "description": description", "error": "error"}`)
+					handlerDetails = []HandlerDetails{
+						{Method: http.MethodPost, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+					}
+				})
+				It("should return error without url and description if invalid response body", func() {
+					responseVisibility, err := client.RegisterVisibility(visibility)
+
+					Expect(err).Should(HaveOccurred())
+					Expect(err).To(MatchError(errors.ResponseError{URL: smServer.URL + web.VisibilitiesURL, StatusCode: handlerDetails[0].ResponseStatusCode}))
+					Expect(responseVisibility).To(BeNil())
+				})
+			})
+
+		})
+
+		Context("When invalid config is set", func() {
+			It("should return error", func() {
+				client = NewClient(http.DefaultClient, "invalidURL")
+				_, err := client.RegisterVisibility(visibility)
 
 				Expect(err).Should(HaveOccurred())
 			})
@@ -436,6 +539,69 @@ var _ = Describe("Service Manager Client test", func() {
 		})
 	})
 
+	Describe("List Visibilities", func() {
+		Context("when there are visibilities registered", func() {
+			BeforeEach(func() {
+				visibilitiesArray := []types.Visibility{*visibility}
+				visibilities := types.Visibilities{Visibilities: visibilitiesArray}
+				responseBody, _ := json.Marshal(visibilities)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return all", func() {
+				result, err := client.ListVisibilities()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Visibilities).To(HaveLen(1))
+				Expect(result.Visibilities[0]).To(Equal(*visibility))
+			})
+		})
+
+		Context("when there are no visibilities registered", func() {
+			BeforeEach(func() {
+				visibilitiesArray := []types.Visibility{}
+				visibilities := types.Visibilities{Visibilities: visibilitiesArray}
+				responseBody, _ := json.Marshal(visibilities)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return empty array", func() {
+				result, err := client.ListVisibilities()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Visibilities).To(HaveLen(0))
+			})
+		})
+
+		Context("when invalid status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.VisibilitiesURL, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+			It("should handle status code != 200", func() {
+				_, err := client.ListVisibilities()
+				Expect(err).Should(HaveOccurred())
+				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusCreated}))
+			})
+		})
+
+		Context("when invalid status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.VisibilitiesURL, ResponseStatusCode: http.StatusBadRequest},
+				}
+			})
+			It("should handle status code > 299", func() {
+				_, err := client.ListVisibilities()
+				Expect(err).Should(HaveOccurred())
+				Expect(err).To(MatchError(errors.ResponseError{StatusCode: http.StatusBadRequest, URL: smServer.URL + web.VisibilitiesURL}))
+			})
+		})
+	})
+
 	Describe("List offerings", func() {
 		Context("when there are offerings provided", func() {
 			BeforeEach(func() {
@@ -597,37 +763,189 @@ var _ = Describe("Service Manager Client test", func() {
 		})
 	})
 
+	Describe("Delete visibility", func() {
+		Context("when an existing visibility is being deleted", func() {
+			BeforeEach(func() {
+				responseBody := []byte("{}")
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodDelete, Path: web.VisibilitiesURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should be successfully removed", func() {
+				err := client.DeleteVisibility("id")
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Context("when service manager returns a non-expected status code", func() {
+			BeforeEach(func() {
+				responseBody := []byte("{}")
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodDelete, Path: web.VisibilitiesURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+			It("should handle error", func() {
+				err := client.DeleteVisibility("id")
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{StatusCode: http.StatusCreated}))
+			})
+		})
+
+		Context("when service manager returns a status code not found", func() {
+			BeforeEach(func() {
+				responseBody := []byte(`{ "description": "Visibility not found" }`)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodDelete, Path: web.VisibilitiesURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+				}
+			})
+			It("should handle error", func() {
+				err := client.DeleteVisibility("id")
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{Description: "Visibility not found", URL: smServer.URL + web.VisibilitiesURL + "/id", StatusCode: http.StatusNotFound}))
+			})
+		})
+	})
+
 	Describe("Update brokers", func() {
 		Context("when an existing broker is being updated", func() {
 			BeforeEach(func() {
-				responseBody := []byte(`{
-					"id": "1234",
-					"name": "broker",
-					"broker_url": "http://broker.com"
-				}`)
+				responseBody, _ := json.Marshal(broker)
 
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodPatch, Path: web.ServiceBrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
 			It("should be successfully removed", func() {
-				updatedBroker, err := client.UpdateBroker("1234", &types.Broker{Name: "broker"})
+				updatedBroker, err := client.UpdateBroker("id", broker)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(updatedBroker.Name).To(Equal("broker"))
+				Expect(updatedBroker).To(Equal(broker))
 			})
 		})
 
 		Context("when a non-existing broker is being updated", func() {
 			BeforeEach(func() {
-				responseBody := []byte(`{}`)
+				responseBody := []byte(`{"description": "Broker not found"}`)
 
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodPatch, Path: web.ServiceBrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
 				}
 			})
 			It("should handle error", func() {
-				_, err := client.UpdateBroker("1234", &types.Broker{Name: "broker"})
+				_, err := client.UpdateBroker("id", broker)
 				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{Description: "Broker not found", URL: smServer.URL + web.ServiceBrokersURL + "/id", StatusCode: http.StatusNotFound}))
+			})
+		})
+
+		Context("when service manager returns a non-expected status code", func() {
+			BeforeEach(func() {
+				responseBody := []byte("{}")
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.ServiceBrokersURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+			It("should handle error", func() {
+				_, err := client.UpdateBroker("id", broker)
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{StatusCode: http.StatusCreated}))
+			})
+		})
+	})
+
+	Describe("Update platforms", func() {
+		Context("when an existing platform is being updated", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(platform)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.PlatformsURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should be successfully removed", func() {
+				updatedPlatform, err := client.UpdatePlatform("id", platform)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(updatedPlatform).To(Equal(platform))
+			})
+		})
+
+		Context("when a non-existing platform is being updated", func() {
+			BeforeEach(func() {
+				responseBody := []byte(`{"description": "Platform not found"}`)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.PlatformsURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+				}
+			})
+			It("should handle error", func() {
+				_, err := client.UpdatePlatform("id", platform)
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{Description: "Platform not found", URL: smServer.URL + web.PlatformsURL + "/id", StatusCode: http.StatusNotFound}))
+			})
+		})
+
+		Context("when service manager returns a non-expected status code", func() {
+			BeforeEach(func() {
+				responseBody := []byte("{}")
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.PlatformsURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+			It("should handle error", func() {
+				_, err := client.UpdatePlatform("id", platform)
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{StatusCode: http.StatusCreated}))
+			})
+		})
+	})
+
+	Describe("Update visibilities", func() {
+		Context("when an existing visibility is being updated", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(visibility)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.VisibilitiesURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should be successfully removed", func() {
+				updatedVisibility, err := client.UpdateVisibility("id", visibility)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(updatedVisibility).To(Equal(visibility))
+			})
+		})
+
+		Context("when a non-existing visibility is being updated", func() {
+			BeforeEach(func() {
+				responseBody := []byte(`{"description": "Visibility not found"}`)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.VisibilitiesURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+				}
+			})
+			It("should handle error", func() {
+				_, err := client.UpdateVisibility("id", visibility)
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{Description: "Visibility not found", URL: smServer.URL + web.VisibilitiesURL + "/id", StatusCode: http.StatusNotFound}))
+			})
+		})
+
+		Context("when service manager returns a non-expected status code", func() {
+			BeforeEach(func() {
+				responseBody := []byte("{}")
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.VisibilitiesURL + "/", ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+			It("should handle error", func() {
+				_, err := client.UpdateVisibility("id", visibility)
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(errors.ResponseError{StatusCode: http.StatusCreated}))
 			})
 		})
 	})

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -48,6 +48,17 @@ type FakeClient struct {
 	deletePlatformReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteVisibilityStub        func(string) error
+	deleteVisibilityMutex       sync.RWMutex
+	deleteVisibilityArgsForCall []struct {
+		arg1 string
+	}
+	deleteVisibilityReturns struct {
+		result1 error
+	}
+	deleteVisibilityReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetInfoStub        func() (*types.Info, error)
 	getInfoMutex       sync.RWMutex
 	getInfoArgsForCall []struct {
@@ -138,6 +149,18 @@ type FakeClient struct {
 		result1 *types.Platforms
 		result2 error
 	}
+	ListVisibilitiesStub        func() (*types.Visibilities, error)
+	listVisibilitiesMutex       sync.RWMutex
+	listVisibilitiesArgsForCall []struct {
+	}
+	listVisibilitiesReturns struct {
+		result1 *types.Visibilities
+		result2 error
+	}
+	listVisibilitiesReturnsOnCall map[int]struct {
+		result1 *types.Visibilities
+		result2 error
+	}
 	RegisterBrokerStub        func(*types.Broker) (*types.Broker, error)
 	registerBrokerMutex       sync.RWMutex
 	registerBrokerArgsForCall []struct {
@@ -162,6 +185,19 @@ type FakeClient struct {
 	}
 	registerPlatformReturnsOnCall map[int]struct {
 		result1 *types.Platform
+		result2 error
+	}
+	RegisterVisibilityStub        func(*types.Visibility) (*types.Visibility, error)
+	registerVisibilityMutex       sync.RWMutex
+	registerVisibilityArgsForCall []struct {
+		arg1 *types.Visibility
+	}
+	registerVisibilityReturns struct {
+		result1 *types.Visibility
+		result2 error
+	}
+	registerVisibilityReturnsOnCall map[int]struct {
+		result1 *types.Visibility
 		result2 error
 	}
 	UpdateBrokerStub        func(string, *types.Broker) (*types.Broker, error)
@@ -190,6 +226,20 @@ type FakeClient struct {
 	}
 	updatePlatformReturnsOnCall map[int]struct {
 		result1 *types.Platform
+		result2 error
+	}
+	UpdateVisibilityStub        func(string, *types.Visibility) (*types.Visibility, error)
+	updateVisibilityMutex       sync.RWMutex
+	updateVisibilityArgsForCall []struct {
+		arg1 string
+		arg2 *types.Visibility
+	}
+	updateVisibilityReturns struct {
+		result1 *types.Visibility
+		result2 error
+	}
+	updateVisibilityReturnsOnCall map[int]struct {
+		result1 *types.Visibility
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -377,6 +427,66 @@ func (fake *FakeClient) DeletePlatformReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deletePlatformReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeleteVisibility(arg1 string) error {
+	fake.deleteVisibilityMutex.Lock()
+	ret, specificReturn := fake.deleteVisibilityReturnsOnCall[len(fake.deleteVisibilityArgsForCall)]
+	fake.deleteVisibilityArgsForCall = append(fake.deleteVisibilityArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("DeleteVisibility", []interface{}{arg1})
+	fake.deleteVisibilityMutex.Unlock()
+	if fake.DeleteVisibilityStub != nil {
+		return fake.DeleteVisibilityStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteVisibilityReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DeleteVisibilityCallCount() int {
+	fake.deleteVisibilityMutex.RLock()
+	defer fake.deleteVisibilityMutex.RUnlock()
+	return len(fake.deleteVisibilityArgsForCall)
+}
+
+func (fake *FakeClient) DeleteVisibilityCalls(stub func(string) error) {
+	fake.deleteVisibilityMutex.Lock()
+	defer fake.deleteVisibilityMutex.Unlock()
+	fake.DeleteVisibilityStub = stub
+}
+
+func (fake *FakeClient) DeleteVisibilityArgsForCall(i int) string {
+	fake.deleteVisibilityMutex.RLock()
+	defer fake.deleteVisibilityMutex.RUnlock()
+	argsForCall := fake.deleteVisibilityArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) DeleteVisibilityReturns(result1 error) {
+	fake.deleteVisibilityMutex.Lock()
+	defer fake.deleteVisibilityMutex.Unlock()
+	fake.DeleteVisibilityStub = nil
+	fake.deleteVisibilityReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeleteVisibilityReturnsOnCall(i int, result1 error) {
+	fake.deleteVisibilityMutex.Lock()
+	defer fake.deleteVisibilityMutex.Unlock()
+	fake.DeleteVisibilityStub = nil
+	if fake.deleteVisibilityReturnsOnCall == nil {
+		fake.deleteVisibilityReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteVisibilityReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -793,6 +903,61 @@ func (fake *FakeClient) ListPlatformsWithQueryReturnsOnCall(i int, result1 *type
 	}{result1, result2}
 }
 
+func (fake *FakeClient) ListVisibilities() (*types.Visibilities, error) {
+	fake.listVisibilitiesMutex.Lock()
+	ret, specificReturn := fake.listVisibilitiesReturnsOnCall[len(fake.listVisibilitiesArgsForCall)]
+	fake.listVisibilitiesArgsForCall = append(fake.listVisibilitiesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListVisibilities", []interface{}{})
+	fake.listVisibilitiesMutex.Unlock()
+	if fake.ListVisibilitiesStub != nil {
+		return fake.ListVisibilitiesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listVisibilitiesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListVisibilitiesCallCount() int {
+	fake.listVisibilitiesMutex.RLock()
+	defer fake.listVisibilitiesMutex.RUnlock()
+	return len(fake.listVisibilitiesArgsForCall)
+}
+
+func (fake *FakeClient) ListVisibilitiesCalls(stub func() (*types.Visibilities, error)) {
+	fake.listVisibilitiesMutex.Lock()
+	defer fake.listVisibilitiesMutex.Unlock()
+	fake.ListVisibilitiesStub = stub
+}
+
+func (fake *FakeClient) ListVisibilitiesReturns(result1 *types.Visibilities, result2 error) {
+	fake.listVisibilitiesMutex.Lock()
+	defer fake.listVisibilitiesMutex.Unlock()
+	fake.ListVisibilitiesStub = nil
+	fake.listVisibilitiesReturns = struct {
+		result1 *types.Visibilities
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListVisibilitiesReturnsOnCall(i int, result1 *types.Visibilities, result2 error) {
+	fake.listVisibilitiesMutex.Lock()
+	defer fake.listVisibilitiesMutex.Unlock()
+	fake.ListVisibilitiesStub = nil
+	if fake.listVisibilitiesReturnsOnCall == nil {
+		fake.listVisibilitiesReturnsOnCall = make(map[int]struct {
+			result1 *types.Visibilities
+			result2 error
+		})
+	}
+	fake.listVisibilitiesReturnsOnCall[i] = struct {
+		result1 *types.Visibilities
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) RegisterBroker(arg1 *types.Broker) (*types.Broker, error) {
 	fake.registerBrokerMutex.Lock()
 	ret, specificReturn := fake.registerBrokerReturnsOnCall[len(fake.registerBrokerArgsForCall)]
@@ -915,6 +1080,69 @@ func (fake *FakeClient) RegisterPlatformReturnsOnCall(i int, result1 *types.Plat
 	}
 	fake.registerPlatformReturnsOnCall[i] = struct {
 		result1 *types.Platform
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) RegisterVisibility(arg1 *types.Visibility) (*types.Visibility, error) {
+	fake.registerVisibilityMutex.Lock()
+	ret, specificReturn := fake.registerVisibilityReturnsOnCall[len(fake.registerVisibilityArgsForCall)]
+	fake.registerVisibilityArgsForCall = append(fake.registerVisibilityArgsForCall, struct {
+		arg1 *types.Visibility
+	}{arg1})
+	fake.recordInvocation("RegisterVisibility", []interface{}{arg1})
+	fake.registerVisibilityMutex.Unlock()
+	if fake.RegisterVisibilityStub != nil {
+		return fake.RegisterVisibilityStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.registerVisibilityReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) RegisterVisibilityCallCount() int {
+	fake.registerVisibilityMutex.RLock()
+	defer fake.registerVisibilityMutex.RUnlock()
+	return len(fake.registerVisibilityArgsForCall)
+}
+
+func (fake *FakeClient) RegisterVisibilityCalls(stub func(*types.Visibility) (*types.Visibility, error)) {
+	fake.registerVisibilityMutex.Lock()
+	defer fake.registerVisibilityMutex.Unlock()
+	fake.RegisterVisibilityStub = stub
+}
+
+func (fake *FakeClient) RegisterVisibilityArgsForCall(i int) *types.Visibility {
+	fake.registerVisibilityMutex.RLock()
+	defer fake.registerVisibilityMutex.RUnlock()
+	argsForCall := fake.registerVisibilityArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) RegisterVisibilityReturns(result1 *types.Visibility, result2 error) {
+	fake.registerVisibilityMutex.Lock()
+	defer fake.registerVisibilityMutex.Unlock()
+	fake.RegisterVisibilityStub = nil
+	fake.registerVisibilityReturns = struct {
+		result1 *types.Visibility
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) RegisterVisibilityReturnsOnCall(i int, result1 *types.Visibility, result2 error) {
+	fake.registerVisibilityMutex.Lock()
+	defer fake.registerVisibilityMutex.Unlock()
+	fake.RegisterVisibilityStub = nil
+	if fake.registerVisibilityReturnsOnCall == nil {
+		fake.registerVisibilityReturnsOnCall = make(map[int]struct {
+			result1 *types.Visibility
+			result2 error
+		})
+	}
+	fake.registerVisibilityReturnsOnCall[i] = struct {
+		result1 *types.Visibility
 		result2 error
 	}{result1, result2}
 }
@@ -1047,6 +1275,70 @@ func (fake *FakeClient) UpdatePlatformReturnsOnCall(i int, result1 *types.Platfo
 	}{result1, result2}
 }
 
+func (fake *FakeClient) UpdateVisibility(arg1 string, arg2 *types.Visibility) (*types.Visibility, error) {
+	fake.updateVisibilityMutex.Lock()
+	ret, specificReturn := fake.updateVisibilityReturnsOnCall[len(fake.updateVisibilityArgsForCall)]
+	fake.updateVisibilityArgsForCall = append(fake.updateVisibilityArgsForCall, struct {
+		arg1 string
+		arg2 *types.Visibility
+	}{arg1, arg2})
+	fake.recordInvocation("UpdateVisibility", []interface{}{arg1, arg2})
+	fake.updateVisibilityMutex.Unlock()
+	if fake.UpdateVisibilityStub != nil {
+		return fake.UpdateVisibilityStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.updateVisibilityReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) UpdateVisibilityCallCount() int {
+	fake.updateVisibilityMutex.RLock()
+	defer fake.updateVisibilityMutex.RUnlock()
+	return len(fake.updateVisibilityArgsForCall)
+}
+
+func (fake *FakeClient) UpdateVisibilityCalls(stub func(string, *types.Visibility) (*types.Visibility, error)) {
+	fake.updateVisibilityMutex.Lock()
+	defer fake.updateVisibilityMutex.Unlock()
+	fake.UpdateVisibilityStub = stub
+}
+
+func (fake *FakeClient) UpdateVisibilityArgsForCall(i int) (string, *types.Visibility) {
+	fake.updateVisibilityMutex.RLock()
+	defer fake.updateVisibilityMutex.RUnlock()
+	argsForCall := fake.updateVisibilityArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) UpdateVisibilityReturns(result1 *types.Visibility, result2 error) {
+	fake.updateVisibilityMutex.Lock()
+	defer fake.updateVisibilityMutex.Unlock()
+	fake.UpdateVisibilityStub = nil
+	fake.updateVisibilityReturns = struct {
+		result1 *types.Visibility
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) UpdateVisibilityReturnsOnCall(i int, result1 *types.Visibility, result2 error) {
+	fake.updateVisibilityMutex.Lock()
+	defer fake.updateVisibilityMutex.Unlock()
+	fake.UpdateVisibilityStub = nil
+	if fake.updateVisibilityReturnsOnCall == nil {
+		fake.updateVisibilityReturnsOnCall = make(map[int]struct {
+			result1 *types.Visibility
+			result2 error
+		})
+	}
+	fake.updateVisibilityReturnsOnCall[i] = struct {
+		result1 *types.Visibility
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1056,6 +1348,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.deleteBrokerMutex.RUnlock()
 	fake.deletePlatformMutex.RLock()
 	defer fake.deletePlatformMutex.RUnlock()
+	fake.deleteVisibilityMutex.RLock()
+	defer fake.deleteVisibilityMutex.RUnlock()
 	fake.getInfoMutex.RLock()
 	defer fake.getInfoMutex.RUnlock()
 	fake.listBrokersMutex.RLock()
@@ -1070,14 +1364,20 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listPlatformsMutex.RUnlock()
 	fake.listPlatformsWithQueryMutex.RLock()
 	defer fake.listPlatformsWithQueryMutex.RUnlock()
+	fake.listVisibilitiesMutex.RLock()
+	defer fake.listVisibilitiesMutex.RUnlock()
 	fake.registerBrokerMutex.RLock()
 	defer fake.registerBrokerMutex.RUnlock()
 	fake.registerPlatformMutex.RLock()
 	defer fake.registerPlatformMutex.RUnlock()
+	fake.registerVisibilityMutex.RLock()
+	defer fake.registerVisibilityMutex.RUnlock()
 	fake.updateBrokerMutex.RLock()
 	defer fake.updateBrokerMutex.RUnlock()
 	fake.updatePlatformMutex.RLock()
 	defer fake.updatePlatformMutex.RUnlock()
+	fake.updateVisibilityMutex.RLock()
+	defer fake.updateVisibilityMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -161,6 +161,20 @@ type FakeClient struct {
 		result1 *types.Visibilities
 		result2 error
 	}
+	ListVisibilitiesWithQueryStub        func(string, string) (*types.Visibilities, error)
+	listVisibilitiesWithQueryMutex       sync.RWMutex
+	listVisibilitiesWithQueryArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	listVisibilitiesWithQueryReturns struct {
+		result1 *types.Visibilities
+		result2 error
+	}
+	listVisibilitiesWithQueryReturnsOnCall map[int]struct {
+		result1 *types.Visibilities
+		result2 error
+	}
 	RegisterBrokerStub        func(*types.Broker) (*types.Broker, error)
 	registerBrokerMutex       sync.RWMutex
 	registerBrokerArgsForCall []struct {
@@ -958,6 +972,70 @@ func (fake *FakeClient) ListVisibilitiesReturnsOnCall(i int, result1 *types.Visi
 	}{result1, result2}
 }
 
+func (fake *FakeClient) ListVisibilitiesWithQuery(arg1 string, arg2 string) (*types.Visibilities, error) {
+	fake.listVisibilitiesWithQueryMutex.Lock()
+	ret, specificReturn := fake.listVisibilitiesWithQueryReturnsOnCall[len(fake.listVisibilitiesWithQueryArgsForCall)]
+	fake.listVisibilitiesWithQueryArgsForCall = append(fake.listVisibilitiesWithQueryArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("ListVisibilitiesWithQuery", []interface{}{arg1, arg2})
+	fake.listVisibilitiesWithQueryMutex.Unlock()
+	if fake.ListVisibilitiesWithQueryStub != nil {
+		return fake.ListVisibilitiesWithQueryStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listVisibilitiesWithQueryReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListVisibilitiesWithQueryCallCount() int {
+	fake.listVisibilitiesWithQueryMutex.RLock()
+	defer fake.listVisibilitiesWithQueryMutex.RUnlock()
+	return len(fake.listVisibilitiesWithQueryArgsForCall)
+}
+
+func (fake *FakeClient) ListVisibilitiesWithQueryCalls(stub func(string, string) (*types.Visibilities, error)) {
+	fake.listVisibilitiesWithQueryMutex.Lock()
+	defer fake.listVisibilitiesWithQueryMutex.Unlock()
+	fake.ListVisibilitiesWithQueryStub = stub
+}
+
+func (fake *FakeClient) ListVisibilitiesWithQueryArgsForCall(i int) (string, string) {
+	fake.listVisibilitiesWithQueryMutex.RLock()
+	defer fake.listVisibilitiesWithQueryMutex.RUnlock()
+	argsForCall := fake.listVisibilitiesWithQueryArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) ListVisibilitiesWithQueryReturns(result1 *types.Visibilities, result2 error) {
+	fake.listVisibilitiesWithQueryMutex.Lock()
+	defer fake.listVisibilitiesWithQueryMutex.Unlock()
+	fake.ListVisibilitiesWithQueryStub = nil
+	fake.listVisibilitiesWithQueryReturns = struct {
+		result1 *types.Visibilities
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListVisibilitiesWithQueryReturnsOnCall(i int, result1 *types.Visibilities, result2 error) {
+	fake.listVisibilitiesWithQueryMutex.Lock()
+	defer fake.listVisibilitiesWithQueryMutex.Unlock()
+	fake.ListVisibilitiesWithQueryStub = nil
+	if fake.listVisibilitiesWithQueryReturnsOnCall == nil {
+		fake.listVisibilitiesWithQueryReturnsOnCall = make(map[int]struct {
+			result1 *types.Visibilities
+			result2 error
+		})
+	}
+	fake.listVisibilitiesWithQueryReturnsOnCall[i] = struct {
+		result1 *types.Visibilities
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) RegisterBroker(arg1 *types.Broker) (*types.Broker, error) {
 	fake.registerBrokerMutex.Lock()
 	ret, specificReturn := fake.registerBrokerReturnsOnCall[len(fake.registerBrokerArgsForCall)]
@@ -1366,6 +1444,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listPlatformsWithQueryMutex.RUnlock()
 	fake.listVisibilitiesMutex.RLock()
 	defer fake.listVisibilitiesMutex.RUnlock()
+	fake.listVisibilitiesWithQueryMutex.RLock()
+	defer fake.listVisibilitiesWithQueryMutex.RUnlock()
 	fake.registerBrokerMutex.RLock()
 	defer fake.registerBrokerMutex.RUnlock()
 	fake.registerPlatformMutex.RLock()

--- a/pkg/types/broker.go
+++ b/pkg/types/broker.go
@@ -46,9 +46,9 @@ func (b *Broker) IsEmpty() bool {
 // TableData returns the data to populate a table
 func (b *Broker) TableData() *TableData {
 	result := &TableData{}
-	result.Headers = []string{"ID", "Name", "URL", "Description", "Created", "Updated"}
+	result.Headers = []string{"ID", "Name", "URL", "Description", "Created", "Updated", "Labels"}
 
-	row := []string{b.ID, b.Name, b.URL, b.Description, b.Created, b.Updated}
+	row := []string{b.ID, b.Name, b.URL, b.Description, b.Created, b.Updated, formatLabels(b.Labels)}
 	result.Data = append(result.Data, row)
 
 	return result
@@ -82,10 +82,10 @@ func (b *Brokers) Message() string {
 // TableData returns the data to populate a table
 func (b *Brokers) TableData() *TableData {
 	result := &TableData{}
-	result.Headers = []string{"ID", "Name", "URL", "Description", "Created", "Updated"}
+	result.Headers = []string{"ID", "Name", "URL", "Description", "Created", "Updated", "Labels"}
 
 	for _, broker := range b.Brokers {
-		row := []string{broker.ID, broker.Name, broker.URL, broker.Description, broker.Created, broker.Updated}
+		row := []string{broker.ID, broker.Name, broker.URL, broker.Description, broker.Created, broker.Updated, formatLabels(broker.Labels)}
 		result.Data = append(result.Data, row)
 	}
 

--- a/pkg/types/platform.go
+++ b/pkg/types/platform.go
@@ -47,8 +47,8 @@ func (p *Platform) IsEmpty() bool {
 func (p *Platform) TableData() *TableData {
 	result := &TableData{}
 
-	result.Headers = []string{"ID", "Name", "Type", "Description", "Created", "Updated"}
-	row := []string{p.ID, p.Name, p.Type, p.Description, p.Created, p.Updated}
+	result.Headers = []string{"ID", "Name", "Type", "Description", "Created", "Updated", "Labels"}
+	row := []string{p.ID, p.Name, p.Type, p.Description, p.Created, p.Updated, formatLabels(p.Labels)}
 
 	if p.Credentials != nil {
 		result.Headers = append(result.Headers, "Username", "Password")
@@ -88,10 +88,10 @@ func (p *Platforms) Message() string {
 // TableData returns the data to populate a table
 func (p *Platforms) TableData() *TableData {
 	result := &TableData{}
-	result.Headers = []string{"ID", "Name", "Type", "Description", "Created", "Updated"}
+	result.Headers = []string{"ID", "Name", "Type", "Description", "Created", "Updated", "Labels"}
 
 	for _, platform := range p.Platforms {
-		row := []string{platform.ID, platform.Name, platform.Type, platform.Description, platform.Created, platform.Updated}
+		row := []string{platform.ID, platform.Name, platform.Type, platform.Description, platform.Created, platform.Updated, formatLabels(platform.Labels)}
 		result.Data = append(result.Data, row)
 	}
 

--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -56,9 +56,9 @@ func (sp *ServicePlan) IsEmpty() bool {
 // TableData returns the data to populate a table
 func (sp *ServicePlan) TableData() *TableData {
 	result := &TableData{}
-	result.Headers = []string{"Plan", "Description"}
+	result.Headers = []string{"Plan", "Description", "ID"}
 
-	row := []string{sp.Name, sp.Description}
+	row := []string{sp.Name, sp.Description, sp.ID}
 	result.Data = append(result.Data, row)
 
 	return result
@@ -92,10 +92,10 @@ func (sp *ServicePlans) IsEmpty() bool {
 // TableData returns the data to populate a table
 func (sp *ServicePlans) TableData() *TableData {
 	result := &TableData{}
-	result.Headers = []string{"Plan", "Description"}
+	result.Headers = []string{"Plan", "Description", "ID"}
 
 	for _, v := range sp.ServicePlans {
-		row := []string{v.Name, v.Description}
+		row := []string{v.Name, v.Description, v.ID}
 		result.Data = append(result.Data, row)
 	}
 

--- a/pkg/types/visibility.go
+++ b/pkg/types/visibility.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package types
+
+import (
+	"fmt"
+	"github.com/Peripli/service-manager/pkg/types"
+)
+
+// Visibility defines the data of a visibility
+type Visibility struct {
+	ID            string       `json:"id,omitempty" yaml:"id,omitempty"`
+	PlatformID    string       `json:"platform_id,omitempty" yaml:"platform_id,omitempty"`
+	ServicePlanID string       `json:"service_plan_id,omitempty" yaml:"service_plan_id,omitempty"`
+	CreatedAt     string       `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt     string       `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	Labels        types.Labels `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// Message title of the table
+func (v *Visibility) Message() string {
+	return ""
+}
+
+// IsEmpty whether the struct is empty
+func (v *Visibility) IsEmpty() bool {
+	return false
+}
+
+// TableData returns the data to populate a table
+func (v *Visibility) TableData() *TableData {
+	result := &TableData{}
+	result.Headers = []string{"ID", "Platform ID", "Service Plan ID", "Labels"}
+	labels := fmt.Sprintf("%v", v.Labels)
+
+	row := []string{v.ID, v.PlatformID, v.ServicePlanID, labels}
+	result.Data = append(result.Data, row)
+
+	return result
+}
+
+// Visibilities wraps an array of Visibilities
+type Visibilities struct {
+	Visibilities []Visibility `json:"visibilities,omitempty" yaml:"visibilities,omitempty"`
+}
+
+// IsEmpty whether the structure is empty
+func (v *Visibilities) IsEmpty() bool {
+	return len(v.Visibilities) == 0
+}
+
+// Message title of the table
+func (v *Visibilities) Message() string {
+	var msg string
+
+	if len(v.Visibilities) == 0 {
+		msg = "No visibilities registered."
+	} else if len(v.Visibilities) == 1 {
+		msg = "One visibility registered."
+	} else {
+		msg = fmt.Sprintf("%d visibilities registered.", len(v.Visibilities))
+	}
+
+	return msg
+}
+
+// TableData returns the data to populate a table
+func (v *Visibilities) TableData() *TableData {
+	result := &TableData{}
+	result.Headers = []string{"ID", "Platform ID", "Service Plan ID", "Labels"}
+
+	for _, visibility := range v.Visibilities {
+		labels := fmt.Sprintf("%v", visibility.Labels)
+		row := []string{visibility.ID, visibility.PlatformID, visibility.ServicePlanID, labels}
+		result.Data = append(result.Data, row)
+	}
+
+	return result
+}

--- a/pkg/types/visibility.go
+++ b/pkg/types/visibility.go
@@ -19,6 +19,7 @@ package types
 import (
 	"fmt"
 	"github.com/Peripli/service-manager/pkg/types"
+	"strings"
 )
 
 // Visibility defines the data of a visibility
@@ -45,9 +46,8 @@ func (v *Visibility) IsEmpty() bool {
 func (v *Visibility) TableData() *TableData {
 	result := &TableData{}
 	result.Headers = []string{"ID", "Platform ID", "Service Plan ID", "Labels"}
-	labels := fmt.Sprintf("%v", v.Labels)
 
-	row := []string{v.ID, v.PlatformID, v.ServicePlanID, labels}
+	row := []string{v.ID, v.PlatformID, v.ServicePlanID, formatLabels(v.Labels)}
 	result.Data = append(result.Data, row)
 
 	return result
@@ -84,10 +84,17 @@ func (v *Visibilities) TableData() *TableData {
 	result.Headers = []string{"ID", "Platform ID", "Service Plan ID", "Labels"}
 
 	for _, visibility := range v.Visibilities {
-		labels := fmt.Sprintf("%v", visibility.Labels)
-		row := []string{visibility.ID, visibility.PlatformID, visibility.ServicePlanID, labels}
+		row := []string{visibility.ID, visibility.PlatformID, visibility.ServicePlanID, formatLabels(visibility.Labels)}
 		result.Data = append(result.Data, row)
 	}
 
 	return result
+}
+
+func formatLabels(labels types.Labels) string {
+	formattedLabels := make([]string, 0, len(labels))
+	for i, v := range labels {
+		formattedLabels = append(formattedLabels, i+"="+strings.Join(v, ","))
+	}
+	return strings.Join(formattedLabels, " ")
 }


### PR DESCRIPTION
## Motivation
Service Manager CLI does not support commands for managing plan visibilities.

## Approach
Introduced 4 new commands:
`smctl list-visibilities`
`smctl register-visibility`
`smctl delete-visibility`
`smctl update-visibility`

#### Pull Request status

- [x] Initial implementation
- [x] Unit tests