### PR TITLE
Field querying on update and delete commands

### DIFF
--- a/internal/cmd/broker/delete_broker.go
+++ b/internal/cmd/broker/delete_broker.go
@@ -18,10 +18,10 @@ package broker
 
 import (
 	"fmt"
+	"github.com/Peripli/service-manager-cli/internal/output"
 	"io"
 	"strings"
 
-	"github.com/Peripli/service-manager-cli/internal/output"
 	"github.com/Peripli/service-manager-cli/internal/util"
 
 	"github.com/spf13/cobra"
@@ -63,33 +63,12 @@ func (dbc *DeleteBrokerCmd) Validate(args []string) error {
 // Run runs the command's logic
 func (dbc *DeleteBrokerCmd) Run() error {
 	fieldQuery := util.GetResourceByNamesQuery(dbc.names)
-	toDeleteBrokers, err := dbc.Client.ListBrokersWithQuery(fieldQuery, "")
+	err := dbc.Client.DeleteBrokersByFieldQuery(fieldQuery)
 	if err != nil {
+		output.PrintMessage(dbc.Output, "Could not delete broker(s). Reason: ")
 		return err
 	}
-	if len(toDeleteBrokers.Brokers) < 1 {
-		output.PrintMessage(dbc.Output, "Service Broker(s) not found\n")
-		return nil
-	}
-
-	deletedBrokers := make(map[string]bool)
-
-	for _, toDelete := range toDeleteBrokers.Brokers {
-		err := dbc.Client.DeleteBroker(toDelete.ID)
-		if err != nil {
-			output.PrintMessage(dbc.Output, "Could not delete broker %s. Reason: %s\n", toDelete.Name, err)
-		} else {
-			output.PrintMessage(dbc.Output, "Broker with name: %s successfully deleted\n", toDelete.Name)
-			deletedBrokers[toDelete.Name] = true
-		}
-	}
-
-	for _, brokerName := range dbc.names {
-		if !deletedBrokers[brokerName] {
-			output.PrintError(dbc.Output, fmt.Errorf("broker with name: %s was not found", brokerName))
-		}
-	}
-
+	output.PrintMessage(dbc.Output, "Service Broker(s) successfully deleted.\n")
 	return nil
 }
 

--- a/internal/cmd/broker/delete_broker_test.go
+++ b/internal/cmd/broker/delete_broker_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Delete brokers command test", func() {
 
 		brokers := &types.Brokers{}
 		brokers.Brokers = []types.Broker{{ID: "1234", Name: "broker-name"}, {ID: "456", Name: "broker2"}}
-		client.ListBrokersWithQueryReturns(brokers, nil)
 	})
 
 	executeWithArgs := func(args []string) error {
@@ -48,26 +47,26 @@ var _ = Describe("Delete brokers command test", func() {
 
 	Context("when existing broker is being deleted forcefully", func() {
 		It("should list success message", func() {
-			client.DeleteBrokerReturns(nil)
+			client.DeleteBrokersByFieldQueryReturns(nil)
 			err := executeWithArgs([]string{"broker-name", "-f"})
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Broker with name: broker-name successfully deleted"))
+			Expect(buffer.String()).To(ContainSubstring("Service Broker(s) successfully deleted."))
 		})
 	})
 
 	Context("when existing broker is being deleted", func() {
 		It("should list success message when confirmed", func() {
-			client.DeleteBrokerReturns(nil)
+			client.DeleteBrokersByFieldQueryReturns(nil)
 			promptBuffer.WriteString("y")
 			err := executeWithArgs([]string{"broker-name"})
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Broker with name: broker-name successfully deleted"))
+			Expect(buffer.String()).To(ContainSubstring("Service Broker(s) successfully deleted."))
 		})
 
 		It("should print delete declined when declined", func() {
-			client.DeleteBrokerReturns(nil)
+			client.DeleteBrokersByFieldQueryReturns(nil)
 			promptBuffer.WriteString("n")
 			err := executeWithArgs([]string{"broker-name"})
 
@@ -76,55 +75,21 @@ var _ = Describe("Delete brokers command test", func() {
 		})
 	})
 
-	Context("when 2 brokers are being deleted", func() {
-		It("should print deleted ones", func() {
-			client.DeleteBrokerReturns(nil)
-			err := executeWithArgs([]string{"broker-name", "broker2", "-f"})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Broker with name: broker-name successfully deleted"))
-			Expect(buffer.String()).To(ContainSubstring("Broker with name: broker2 successfully deleted"))
-		})
-	})
-
-	Context("when 2 brokers are being deleted and one is not found", func() {
-		It("should print which was not found", func() {
-			client.DeleteBrokerReturns(nil)
-			err := executeWithArgs([]string{"broker-name", "broker", "-f"})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Broker with name: broker-name successfully deleted"))
-			Expect(buffer.String()).To(ContainSubstring("broker with name: broker was not found"))
-		})
-	})
-
-	Context("when 3 brokers are being deleted and one is not found", func() {
-		It("should print which was not found", func() {
-			client.DeleteBrokerReturns(nil)
-			err := executeWithArgs([]string{"broker-name", "non-existing", "broker2", "-f"})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Broker with name: broker-name successfully deleted"))
-			Expect(buffer.String()).To(ContainSubstring("Broker with name: broker2 successfully deleted"))
-			Expect(buffer.String()).To(ContainSubstring("broker with name: non-existing was not found"))
-		})
-	})
-
-	Context("when non-existing broker is being deleted", func() {
+	Context("when non-existing brokers are being deleted", func() {
 		It("should return error message", func() {
 			expectedError := errors.ResponseError{StatusCode: http.StatusNotFound}
 			client.ListBrokersWithQueryReturns(&types.Brokers{}, nil)
-			client.DeleteBrokerReturns(expectedError)
+			client.DeleteBrokersByFieldQueryReturns(expectedError)
 			err := executeWithArgs([]string{"non-existing-name", "-f"})
 
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Service Broker(s) not found"))
+			Expect(err).Should(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Could not delete broker(s)."))
 		})
 	})
 
 	Context("when no arguments are provided", func() {
 		It("should print required arguments", func() {
-			client.DeleteBrokerReturns(nil)
+			client.DeleteBrokersByFieldQueryReturns(nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).Should(HaveOccurred())

--- a/internal/cmd/broker/delete_broker_test.go
+++ b/internal/cmd/broker/delete_broker_test.go
@@ -20,7 +20,7 @@ func TestDeleteBrokerCmd(t *testing.T) {
 	RunSpecs(t, "")
 }
 
-var _ = Describe("List brokers command test", func() {
+var _ = Describe("Delete brokers command test", func() {
 
 	var client *smclientfakes.FakeClient
 	var command *DeleteBrokerCmd
@@ -34,9 +34,9 @@ var _ = Describe("List brokers command test", func() {
 		context := &cmd.Context{Output: buffer, Client: client}
 		command = NewDeleteBrokerCmd(context, promptBuffer)
 
-		var brokers *types.Brokers = &types.Brokers{}
+		brokers := &types.Brokers{}
 		brokers.Brokers = []types.Broker{{ID: "1234", Name: "broker-name"}, {ID: "456", Name: "broker2"}}
-		client.ListBrokersReturns(brokers, nil)
+		client.ListBrokersWithQueryReturns(brokers, nil)
 	})
 
 	executeWithArgs := func(args []string) error {
@@ -113,9 +113,11 @@ var _ = Describe("List brokers command test", func() {
 	Context("when non-existing broker is being deleted", func() {
 		It("should return error message", func() {
 			expectedError := errors.ResponseError{StatusCode: http.StatusNotFound}
+			client.ListBrokersWithQueryReturns(&types.Brokers{}, nil)
 			client.DeleteBrokerReturns(expectedError)
-			executeWithArgs([]string{"non-existing-name", "-f"})
+			err := executeWithArgs([]string{"non-existing-name", "-f"})
 
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring("Service Broker(s) not found"))
 		})
 	})

--- a/internal/cmd/broker/update_broker.go
+++ b/internal/cmd/broker/update_broker.go
@@ -19,6 +19,7 @@ package broker
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/Peripli/service-manager-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -62,7 +63,7 @@ func (ubc *UpdateBrokerCmd) Validate(args []string) error {
 
 // Run runs the command's logic
 func (ubc *UpdateBrokerCmd) Run() error {
-	fieldQuery := "name+=+" + ubc.name
+	fieldQuery := "name+=+" + url.QueryEscape(ubc.name)
 	toUpdateBrokers, err := ubc.Client.ListBrokersWithQuery(fieldQuery, "")
 	if err != nil {
 		return err

--- a/internal/cmd/broker/update_broker.go
+++ b/internal/cmd/broker/update_broker.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 
 	"github.com/Peripli/service-manager-cli/internal/output"
-	"github.com/Peripli/service-manager-cli/internal/util"
-
 	"github.com/spf13/cobra"
 
 	"github.com/Peripli/service-manager-cli/internal/cmd"
@@ -64,16 +62,15 @@ func (ubc *UpdateBrokerCmd) Validate(args []string) error {
 
 // Run runs the command's logic
 func (ubc *UpdateBrokerCmd) Run() error {
-	allBrokers, err := ubc.Client.ListBrokers()
+	fieldQuery := "name+=+" + ubc.name
+	toUpdateBrokers, err := ubc.Client.ListBrokersWithQuery(fieldQuery, "")
 	if err != nil {
 		return err
 	}
-
-	brokerWithName := util.GetBrokersByName(allBrokers, []string{ubc.name})
-	if len(brokerWithName) < 1 {
+	if len(toUpdateBrokers.Brokers) < 1 {
 		return fmt.Errorf("broker with name %s not found", ubc.name)
 	}
-	toUpdateBroker := brokerWithName[0]
+	toUpdateBroker := toUpdateBrokers.Brokers[0]
 	result, err := ubc.Client.UpdateBroker(toUpdateBroker.ID, ubc.updatedBroker)
 	if err != nil {
 		return err

--- a/internal/cmd/broker/update_broker_test.go
+++ b/internal/cmd/broker/update_broker_test.go
@@ -3,13 +3,12 @@ package broker
 import (
 	"encoding/json"
 	"errors"
+	"gopkg.in/yaml.v2"
 	"testing"
 
+	"bytes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	yaml "gopkg.in/yaml.v2"
-
-	"bytes"
 
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
@@ -26,11 +25,7 @@ var _ = Describe("Update broker command test", func() {
 	var client *smclientfakes.FakeClient
 	var command *UpdateBrokerCmd
 	var buffer *bytes.Buffer
-	broker := types.Broker{
-		Name: "broker1",
-		ID:   "id1",
-		URL:  "http://broker1.com",
-	}
+	var broker types.Broker
 
 	BeforeEach(func() {
 		buffer = &bytes.Buffer{}
@@ -39,89 +34,133 @@ var _ = Describe("Update broker command test", func() {
 		command = NewUpdateBrokerCmd(context)
 	})
 
-	executeWithArgs := func(args []string) error {
-		commandToRun := command.Prepare(cmd.SmPrepare)
-		commandToRun.SetArgs(args)
-
-		return commandToRun.Execute()
+	validUpdateBrokerExecution := func(args ...string) error {
+		broker = types.Broker{
+			Name:        "broker1",
+			ID:          "id",
+			URL:         "http://broker1.com",
+			Description: "description",
+		}
+		brokers := &types.Brokers{Brokers: []types.Broker{broker}}
+		client.ListBrokersWithQueryReturns(brokers, nil)
+		_ = json.Unmarshal([]byte(args[1]), broker)
+		client.UpdateBrokerReturns(&broker, nil)
+		ubCmd := command.Prepare(cmd.SmPrepare)
+		ubCmd.SetArgs(args)
+		return ubCmd.Execute()
 	}
 
-	Context("when existing broker is being updated", func() {
-		It("should print updated broker", func() {
-			updatedBroker := broker
-			updatedBroker.Name = "updated-name"
-			client.UpdateBrokerReturns(&updatedBroker, nil)
-			client.ListBrokersReturns(&types.Brokers{Brokers: []types.Broker{broker}}, nil)
-			err := executeWithArgs([]string{broker.Name, `{"name": "` + updatedBroker.Name + `"}`})
+	invalidUpdateBrokerExecution := func(args ...string) error {
+		ubCmd := command.Prepare(cmd.SmPrepare)
+		ubCmd.SetArgs(args)
+		return ubCmd.Execute()
+	}
 
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring(updatedBroker.TableData().String()))
+	Describe("Valid request", func() {
+		Context("With necessary arguments provided", func() {
+			It("broker should be updated", func() {
+
+				err := validUpdateBrokerExecution("broker1", `{"description":"newDescription"}`)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring(broker.TableData().String()))
+			})
+
+			It("argument values should be as expected", func() {
+				err := validUpdateBrokerExecution("broker1", `{"description":"newDescription"}`)
+
+				id, broker := client.UpdateBrokerArgsForCall(0)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(id).To(Equal("id"))
+				Expect(broker).To(Equal(&types.Broker{Description: "newDescription"}))
+			})
+		})
+
+		Context("With json format flag", func() {
+			It("should be printed in json format", func() {
+				err := validUpdateBrokerExecution("broker1", `{"description":"newDescription"}`, "--output", "json")
+
+				jsonByte, _ := json.MarshalIndent(broker, "", "  ")
+				jsonOutputExpected := string(jsonByte) + "\n"
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(Equal(jsonOutputExpected))
+			})
+		})
+
+		Context("With yaml format flag", func() {
+			It("should be printed in yaml format", func() {
+				err := validUpdateBrokerExecution("broker1", `{"description":"newDescription"}`, "--output", "yaml")
+
+				yamlByte, _ := yaml.Marshal(broker)
+				yamlOutputExpected := string(yamlByte) + "\n"
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(Equal(yamlOutputExpected))
+			})
 		})
 	})
 
-	Context("when non-existing broker is being updated", func() {
-		It("should throw error", func() {
-			client.ListBrokersReturns(&types.Brokers{Brokers: []types.Broker{broker}}, nil)
-			err := executeWithArgs([]string{"non-existing", "{}"})
+	Describe("Invalid request", func() {
+		Context("With missing arguments", func() {
+			It("Should return error missing name", func() {
+				err := invalidUpdateBrokerExecution([]string{}...)
 
-			Expect(err).Should(HaveOccurred())
-			Expect(err).To(MatchError("broker with name non-existing not found"))
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("[name] is required"))
+			})
+			It("Should return error missing json", func() {
+				err := invalidUpdateBrokerExecution("broker1")
+
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("nothing to update. Broker JSON is not provided"))
+			})
 		})
 	})
 
-	Context("when list brokers returns an error", func() {
-		It("should be handled", func() {
-			client.ListBrokersReturns(nil, errors.New("error retrieving brokers"))
-			err := executeWithArgs([]string{"non-existing", "{}"})
+	Context("When non existing broker updated", func() {
+		It("should return error", func() {
+			client.ListBrokersWithQueryReturns(&types.Brokers{}, nil)
+
+			err := invalidUpdateBrokerExecution("broker1", `{"description":"newDescription"}`)
 
 			Expect(err).Should(HaveOccurred())
-			Expect(err).To(MatchError("error retrieving brokers"))
+			Expect(err.Error()).To(Equal("broker with name broker1 not found"))
 		})
 	})
 
-	Context("when name is not provided", func() {
-		It("should throw error", func() {
-			err := executeWithArgs([]string{})
+	Context("With error from http client", func() {
+		It("Should return error", func() {
+			expectedErr := errors.New("http client error")
+			brokers := &types.Brokers{Brokers: []types.Broker{broker}}
+			client.ListBrokersWithQueryReturns(brokers, nil)
+			client.UpdateBrokerReturns(nil, expectedErr)
+
+			err := invalidUpdateBrokerExecution("broker1", `{"description":"newDescription"}`)
+
 			Expect(err).Should(HaveOccurred())
-			Expect(err).To(MatchError("[name] is required"))
+			Expect(err).To(MatchError(expectedErr.Error()))
 		})
 	})
 
-	Context("when json is not provided", func() {
-		It("should throw error", func() {
-			err := executeWithArgs([]string{"broker"})
+	Context("With invalid output format", func() {
+		It("should return error", func() {
+			invFormat := "invalid-format"
+			err := invalidUpdateBrokerExecution("broker1", `{"description":"newDescription"}`, "--output", invFormat)
+
 			Expect(err).Should(HaveOccurred())
-			Expect(err).To(MatchError("nothing to update. Broker JSON is not provided"))
+			Expect(err.Error()).To(Equal("unknown output: " + invFormat))
 		})
 	})
 
 	Context("when json is invalid", func() {
 		It("should throw error", func() {
-			err := executeWithArgs([]string{"broker", "{name: none}"})
+			err := invalidUpdateBrokerExecution("broker1", "{name: none}")
+
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("broker JSON is invalid"))
 		})
 	})
 
-	Context("when output flag is used", func() {
-		It("should print in json", func() {
-			client.UpdateBrokerReturns(&broker, nil)
-			client.ListBrokersReturns(&types.Brokers{Brokers: []types.Broker{broker}}, nil)
-			executeWithArgs([]string{broker.Name, `{"name": "broker"}`, "-o", "json"})
-
-			jsonByte, _ := json.MarshalIndent(broker, "", "  ")
-			jsonOutputExpected := string(jsonByte) + "\n"
-			Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
-		})
-
-		It("should print in yaml", func() {
-			client.UpdateBrokerReturns(&broker, nil)
-			client.ListBrokersReturns(&types.Brokers{Brokers: []types.Broker{broker}}, nil)
-			executeWithArgs([]string{broker.Name, `{"name": "broker"}`, "-o", "yaml"})
-
-			yamlByte, _ := yaml.Marshal(broker)
-			yamlOutputExpected := string(yamlByte) + "\n"
-			Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
-		})
-	})
 })

--- a/internal/cmd/platform/delete_platform.go
+++ b/internal/cmd/platform/delete_platform.go
@@ -57,20 +57,20 @@ func (dpc *DeletePlatformCmd) Validate(args []string) error {
 
 // Run runs the command's logic
 func (dpc *DeletePlatformCmd) Run() error {
-	allPlatforms, err := dpc.Client.ListPlatforms()
+	fieldQuery := util.GetResourceByNamesQuery(dpc.names)
+	toDeletePlatforms, err := dpc.Client.ListPlatformsWithQuery(fieldQuery, "")
 	if err != nil {
 		return err
 	}
 
-	toDeletePlatforms := util.GetPlatformsByName(allPlatforms, dpc.names)
-	if len(toDeletePlatforms) < 1 {
+	if len(toDeletePlatforms.Platforms) < 1 {
 		output.PrintMessage(dpc.Output, "Platform(s) not found\n")
 		return nil
 	}
 
 	deletedPlatforms := make(map[string]bool)
 
-	for _, toDelete := range toDeletePlatforms {
+	for _, toDelete := range toDeletePlatforms.Platforms {
 		err := dpc.Client.DeletePlatform(toDelete.ID)
 		if err != nil {
 			output.PrintMessage(dpc.Output, "Could not delete platform %s. Reason %s\n", toDelete.Name, err)

--- a/internal/cmd/platform/delete_platform.go
+++ b/internal/cmd/platform/delete_platform.go
@@ -58,34 +58,12 @@ func (dpc *DeletePlatformCmd) Validate(args []string) error {
 // Run runs the command's logic
 func (dpc *DeletePlatformCmd) Run() error {
 	fieldQuery := util.GetResourceByNamesQuery(dpc.names)
-	toDeletePlatforms, err := dpc.Client.ListPlatformsWithQuery(fieldQuery, "")
+	err := dpc.Client.DeletePlatformsByFieldQuery(fieldQuery)
 	if err != nil {
+		output.PrintMessage(dpc.Output, "Could not delete platform(s). Reason: ")
 		return err
 	}
-
-	if len(toDeletePlatforms.Platforms) < 1 {
-		output.PrintMessage(dpc.Output, "Platform(s) not found\n")
-		return nil
-	}
-
-	deletedPlatforms := make(map[string]bool)
-
-	for _, toDelete := range toDeletePlatforms.Platforms {
-		err := dpc.Client.DeletePlatform(toDelete.ID)
-		if err != nil {
-			output.PrintMessage(dpc.Output, "Could not delete platform %s. Reason %s\n", toDelete.Name, err)
-		} else {
-			output.PrintMessage(dpc.Output, "Platform with name: %s successfully deleted\n", toDelete.Name)
-			deletedPlatforms[toDelete.Name] = true
-		}
-	}
-
-	for _, platformName := range dpc.names {
-		if _, deleted := deletedPlatforms[platformName]; !deleted {
-			output.PrintError(dpc.Output, fmt.Errorf("platform with name: %s was not found", platformName))
-		}
-	}
-
+	output.PrintMessage(dpc.Output, "Platform(s) successfully deleted.\n")
 	return nil
 }
 

--- a/internal/cmd/platform/delete_platform_test.go
+++ b/internal/cmd/platform/delete_platform_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Delete platforms command test", func() {
 
 		platforms := &types.Platforms{}
 		platforms.Platforms = []types.Platform{{ID: "1234", Name: "platform-name"}, {ID: "456", Name: "platform2"}}
-		client.ListPlatformsWithQueryReturns(platforms, nil)
 	})
 
 	executeWithArgs := func(args []string) error {
@@ -48,26 +47,26 @@ var _ = Describe("Delete platforms command test", func() {
 
 	Context("when existing platform is being deleted forcefully", func() {
 		It("should list success message", func() {
-			client.DeletePlatformReturns(nil)
+			client.DeletePlatformsByFieldQueryReturns(nil)
 			err := executeWithArgs([]string{"platform-name", "-f"})
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Platform with name: platform-name successfully deleted"))
+			Expect(buffer.String()).To(ContainSubstring("Platform(s) successfully deleted."))
 		})
 	})
 
 	Context("when existing platform is being deleted", func() {
 		It("should list success message when confirmed", func() {
-			client.DeletePlatformReturns(nil)
+			client.DeletePlatformsByFieldQueryReturns(nil)
 			promptBuffer.WriteString("y")
 			err := executeWithArgs([]string{"platform-name"})
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Platform with name: platform-name successfully deleted"))
+			Expect(buffer.String()).To(ContainSubstring("Platform(s) successfully deleted."))
 		})
 
 		It("should print delete declined when declined", func() {
-			client.DeletePlatformReturns(nil)
+			client.DeletePlatformsByFieldQueryReturns(nil)
 			promptBuffer.WriteString("n")
 			err := executeWithArgs([]string{"platform-name"})
 
@@ -77,43 +76,21 @@ var _ = Describe("Delete platforms command test", func() {
 
 	})
 
-	Context("when 2 platforms are being deleted", func() {
-		It("should success for both of them", func() {
-			client.DeletePlatformReturns(nil)
-			err := executeWithArgs([]string{"platform-name", "platform2", "-f"})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Platform with name: platform-name successfully deleted"))
-			Expect(buffer.String()).To(ContainSubstring("Platform with name: platform2 successfully deleted"))
-		})
-	})
-
-	Context("when 2 platforms are being deleted and one is not found", func() {
-		It("should print the name of the not found", func() {
-			client.DeletePlatformReturns(nil)
-			err := executeWithArgs([]string{"platform-name", "platform", "-f"})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Platform with name: platform-name successfully deleted"))
-			Expect(buffer.String()).To(ContainSubstring("platform with name: platform was not found"))
-		})
-	})
-
 	Context("when non-existing platform is being deleted", func() {
 		It("should return error message", func() {
 			expectedError := errors.ResponseError{StatusCode: http.StatusNotFound}
 			client.ListPlatformsWithQueryReturns(&types.Platforms{}, nil)
-			client.DeletePlatformReturns(expectedError)
+			client.DeletePlatformsByFieldQueryReturns(expectedError)
 			err := executeWithArgs([]string{"non-existing-name", "-f"})
 
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Platform(s) not found"))
+			Expect(err).Should(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Could not delete platform(s)."))
 		})
 	})
 
 	Context("when no arguments are provided", func() {
 		It("should print required arguments", func() {
-			client.DeletePlatformReturns(nil)
+			client.DeletePlatformsByFieldQueryReturns(nil)
 			err := executeWithArgs([]string{})
 
 			Expect(err).Should(HaveOccurred())

--- a/internal/cmd/platform/delete_platform_test.go
+++ b/internal/cmd/platform/delete_platform_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Delete platforms command test", func() {
 
 		platforms := &types.Platforms{}
 		platforms.Platforms = []types.Platform{{ID: "1234", Name: "platform-name"}, {ID: "456", Name: "platform2"}}
-		client.ListPlatformsReturns(platforms, nil)
+		client.ListPlatformsWithQueryReturns(platforms, nil)
 	})
 
 	executeWithArgs := func(args []string) error {
@@ -102,6 +102,7 @@ var _ = Describe("Delete platforms command test", func() {
 	Context("when non-existing platform is being deleted", func() {
 		It("should return error message", func() {
 			expectedError := errors.ResponseError{StatusCode: http.StatusNotFound}
+			client.ListPlatformsWithQueryReturns(&types.Platforms{}, nil)
 			client.DeletePlatformReturns(expectedError)
 			err := executeWithArgs([]string{"non-existing-name", "-f"})
 

--- a/internal/cmd/platform/update_platform.go
+++ b/internal/cmd/platform/update_platform.go
@@ -19,6 +19,7 @@ package platform
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/Peripli/service-manager-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -62,7 +63,7 @@ func (upc *UpdatePlatformCmd) Validate(args []string) error {
 
 // Run runs the command's logic
 func (upc *UpdatePlatformCmd) Run() error {
-	fieldQuery := "name+=+" + upc.name
+	fieldQuery := "name+=+" + url.QueryEscape(upc.name)
 	toUpdatePlatforms, err := upc.Client.ListPlatformsWithQuery(fieldQuery, "")
 	if err != nil {
 		return err

--- a/internal/cmd/platform/update_platform.go
+++ b/internal/cmd/platform/update_platform.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 
 	"github.com/Peripli/service-manager-cli/internal/output"
-	"github.com/Peripli/service-manager-cli/internal/util"
-
 	"github.com/spf13/cobra"
 
 	"github.com/Peripli/service-manager-cli/internal/cmd"
@@ -64,16 +62,15 @@ func (upc *UpdatePlatformCmd) Validate(args []string) error {
 
 // Run runs the command's logic
 func (upc *UpdatePlatformCmd) Run() error {
-	allPlatforms, err := upc.Client.ListPlatforms()
+	fieldQuery := "name+=+" + upc.name
+	toUpdatePlatforms, err := upc.Client.ListPlatformsWithQuery(fieldQuery, "")
 	if err != nil {
 		return err
 	}
-
-	platformWithName := util.GetPlatformsByName(allPlatforms, []string{upc.name})
-	if len(platformWithName) < 1 {
+	if len(toUpdatePlatforms.Platforms) < 1 {
 		return fmt.Errorf("platform with name %s not found", upc.name)
 	}
-	toUpdatePlatform := platformWithName[0]
+	toUpdatePlatform := toUpdatePlatforms.Platforms[0]
 	result, err := upc.Client.UpdatePlatform(toUpdatePlatform.ID, upc.updatedPlatform)
 	if err != nil {
 		return err

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -47,6 +47,9 @@ func ValidateURL(URL string) error {
 
 // GetResourceByNamesQuery returns field query for retrieving all instances of resource with given names
 func GetResourceByNamesQuery(names []string) string {
+	for i := range names {
+		names[i] = url.QueryEscape(names[i])
+	}
 	return "name+in+[" + strings.Join(names, "||") + "]"
 }
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -25,8 +25,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/Peripli/service-manager-cli/pkg/types"
 )
 
 // ValidateURL validates a URL
@@ -47,35 +45,9 @@ func ValidateURL(URL string) error {
 	return nil
 }
 
-// GetBrokersByName returns array of brokers with the searched names
-func GetBrokersByName(brokers *types.Brokers, names []string) []types.Broker {
-	result := make([]types.Broker, 0)
-	brokersMap := make(map[string]types.Broker)
-	for _, broker := range brokers.Brokers {
-		brokersMap[broker.Name] = broker
-	}
-
-	for _, name := range names {
-		if _, exists := brokersMap[name]; exists {
-			result = append(result, brokersMap[name])
-		}
-	}
-	return result
-}
-
-// GetPlatformsByName returns array of platforms with the searched names
-func GetPlatformsByName(platforms *types.Platforms, names []string) []types.Platform {
-	result := make([]types.Platform, 0)
-	platformsMap := make(map[string]types.Platform)
-	for _, platform := range platforms.Platforms {
-		platformsMap[platform.Name] = platform
-	}
-	for _, name := range names {
-		if _, exists := platformsMap[name]; exists {
-			result = append(result, platformsMap[name])
-		}
-	}
-	return result
+// GetResourceByNamesQuery returns field query for retrieving all instances of resource with given names
+func GetResourceByNamesQuery(names []string) string {
+	return "name+in+[" + strings.Join(names, "||") + "]"
 }
 
 // BuildHTTPClient builds custom http client with configured ssl validation

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -47,8 +47,10 @@ type Client interface {
 	ListVisibilitiesWithQuery(string, string) (*types.Visibilities, error)
 	ListVisibilities() (*types.Visibilities, error)
 	DeleteBroker(string) error
+	DeleteBrokersByFieldQuery(string) error
 	DeletePlatform(string) error
 	DeleteVisibility(string) error
+	DeletePlatformsByFieldQuery(string) error
 	UpdateBroker(string, *types.Broker) (*types.Broker, error)
 	UpdatePlatform(string, *types.Platform) (*types.Platform, error)
 	UpdateVisibility(string, *types.Visibility) (*types.Visibility, error)
@@ -252,23 +254,31 @@ func (client *serviceManagerClient) list(result interface{}, path string) error 
 	return httputil.UnmarshalResponse(resp, &result)
 }
 
+func (client *serviceManagerClient) DeleteBrokersByFieldQuery(query string) error {
+	return client.delete(web.ServiceBrokersURL + "?fieldQuery=" + query)
+}
+
 // DeleteBroker deletes a broker with given id from service manager
 func (client *serviceManagerClient) DeleteBroker(id string) error {
-	return client.delete(id, web.ServiceBrokersURL)
+	return client.delete(web.ServiceBrokersURL + "/" + id)
+}
+
+func (client *serviceManagerClient) DeletePlatformsByFieldQuery(query string) error {
+	return client.delete(web.PlatformsURL + "?fieldQuery=" + query)
 }
 
 // DeletePlatform deletes a platform with given id from service manager
 func (client *serviceManagerClient) DeletePlatform(id string) error {
-	return client.delete(id, web.PlatformsURL)
+	return client.delete(web.PlatformsURL + "/" + id)
 }
 
 // DeleteVisibility deletes a visibility with given id from service manager
 func (client *serviceManagerClient) DeleteVisibility(id string) error {
-	return client.delete(id, web.VisibilitiesURL)
+	return client.delete(web.VisibilitiesURL + "/" + id)
 }
 
-func (client *serviceManagerClient) delete(id, path string) error {
-	resp, err := client.Call(http.MethodDelete, path+"/"+id, nil)
+func (client *serviceManagerClient) delete(path string) error {
+	resp, err := client.Call(http.MethodDelete, path, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -37,6 +37,17 @@ type FakeClient struct {
 	deleteBrokerReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteBrokersByFieldQueryStub        func(string) error
+	deleteBrokersByFieldQueryMutex       sync.RWMutex
+	deleteBrokersByFieldQueryArgsForCall []struct {
+		arg1 string
+	}
+	deleteBrokersByFieldQueryReturns struct {
+		result1 error
+	}
+	deleteBrokersByFieldQueryReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeletePlatformStub        func(string) error
 	deletePlatformMutex       sync.RWMutex
 	deletePlatformArgsForCall []struct {
@@ -46,6 +57,17 @@ type FakeClient struct {
 		result1 error
 	}
 	deletePlatformReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DeletePlatformsByFieldQueryStub        func(string) error
+	deletePlatformsByFieldQueryMutex       sync.RWMutex
+	deletePlatformsByFieldQueryArgsForCall []struct {
+		arg1 string
+	}
+	deletePlatformsByFieldQueryReturns struct {
+		result1 error
+	}
+	deletePlatformsByFieldQueryReturnsOnCall map[int]struct {
 		result1 error
 	}
 	DeleteVisibilityStub        func(string) error
@@ -385,6 +407,66 @@ func (fake *FakeClient) DeleteBrokerReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeClient) DeleteBrokersByFieldQuery(arg1 string) error {
+	fake.deleteBrokersByFieldQueryMutex.Lock()
+	ret, specificReturn := fake.deleteBrokersByFieldQueryReturnsOnCall[len(fake.deleteBrokersByFieldQueryArgsForCall)]
+	fake.deleteBrokersByFieldQueryArgsForCall = append(fake.deleteBrokersByFieldQueryArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("DeleteBrokersByFieldQuery", []interface{}{arg1})
+	fake.deleteBrokersByFieldQueryMutex.Unlock()
+	if fake.DeleteBrokersByFieldQueryStub != nil {
+		return fake.DeleteBrokersByFieldQueryStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteBrokersByFieldQueryReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DeleteBrokersByFieldQueryCallCount() int {
+	fake.deleteBrokersByFieldQueryMutex.RLock()
+	defer fake.deleteBrokersByFieldQueryMutex.RUnlock()
+	return len(fake.deleteBrokersByFieldQueryArgsForCall)
+}
+
+func (fake *FakeClient) DeleteBrokersByFieldQueryCalls(stub func(string) error) {
+	fake.deleteBrokersByFieldQueryMutex.Lock()
+	defer fake.deleteBrokersByFieldQueryMutex.Unlock()
+	fake.DeleteBrokersByFieldQueryStub = stub
+}
+
+func (fake *FakeClient) DeleteBrokersByFieldQueryArgsForCall(i int) string {
+	fake.deleteBrokersByFieldQueryMutex.RLock()
+	defer fake.deleteBrokersByFieldQueryMutex.RUnlock()
+	argsForCall := fake.deleteBrokersByFieldQueryArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) DeleteBrokersByFieldQueryReturns(result1 error) {
+	fake.deleteBrokersByFieldQueryMutex.Lock()
+	defer fake.deleteBrokersByFieldQueryMutex.Unlock()
+	fake.DeleteBrokersByFieldQueryStub = nil
+	fake.deleteBrokersByFieldQueryReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeleteBrokersByFieldQueryReturnsOnCall(i int, result1 error) {
+	fake.deleteBrokersByFieldQueryMutex.Lock()
+	defer fake.deleteBrokersByFieldQueryMutex.Unlock()
+	fake.DeleteBrokersByFieldQueryStub = nil
+	if fake.deleteBrokersByFieldQueryReturnsOnCall == nil {
+		fake.deleteBrokersByFieldQueryReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteBrokersByFieldQueryReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeClient) DeletePlatform(arg1 string) error {
 	fake.deletePlatformMutex.Lock()
 	ret, specificReturn := fake.deletePlatformReturnsOnCall[len(fake.deletePlatformArgsForCall)]
@@ -441,6 +523,66 @@ func (fake *FakeClient) DeletePlatformReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deletePlatformReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeletePlatformsByFieldQuery(arg1 string) error {
+	fake.deletePlatformsByFieldQueryMutex.Lock()
+	ret, specificReturn := fake.deletePlatformsByFieldQueryReturnsOnCall[len(fake.deletePlatformsByFieldQueryArgsForCall)]
+	fake.deletePlatformsByFieldQueryArgsForCall = append(fake.deletePlatformsByFieldQueryArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("DeletePlatformsByFieldQuery", []interface{}{arg1})
+	fake.deletePlatformsByFieldQueryMutex.Unlock()
+	if fake.DeletePlatformsByFieldQueryStub != nil {
+		return fake.DeletePlatformsByFieldQueryStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deletePlatformsByFieldQueryReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DeletePlatformsByFieldQueryCallCount() int {
+	fake.deletePlatformsByFieldQueryMutex.RLock()
+	defer fake.deletePlatformsByFieldQueryMutex.RUnlock()
+	return len(fake.deletePlatformsByFieldQueryArgsForCall)
+}
+
+func (fake *FakeClient) DeletePlatformsByFieldQueryCalls(stub func(string) error) {
+	fake.deletePlatformsByFieldQueryMutex.Lock()
+	defer fake.deletePlatformsByFieldQueryMutex.Unlock()
+	fake.DeletePlatformsByFieldQueryStub = stub
+}
+
+func (fake *FakeClient) DeletePlatformsByFieldQueryArgsForCall(i int) string {
+	fake.deletePlatformsByFieldQueryMutex.RLock()
+	defer fake.deletePlatformsByFieldQueryMutex.RUnlock()
+	argsForCall := fake.deletePlatformsByFieldQueryArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) DeletePlatformsByFieldQueryReturns(result1 error) {
+	fake.deletePlatformsByFieldQueryMutex.Lock()
+	defer fake.deletePlatformsByFieldQueryMutex.Unlock()
+	fake.DeletePlatformsByFieldQueryStub = nil
+	fake.deletePlatformsByFieldQueryReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeletePlatformsByFieldQueryReturnsOnCall(i int, result1 error) {
+	fake.deletePlatformsByFieldQueryMutex.Lock()
+	defer fake.deletePlatformsByFieldQueryMutex.Unlock()
+	fake.DeletePlatformsByFieldQueryStub = nil
+	if fake.deletePlatformsByFieldQueryReturnsOnCall == nil {
+		fake.deletePlatformsByFieldQueryReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deletePlatformsByFieldQueryReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -1424,8 +1566,12 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.callMutex.RUnlock()
 	fake.deleteBrokerMutex.RLock()
 	defer fake.deleteBrokerMutex.RUnlock()
+	fake.deleteBrokersByFieldQueryMutex.RLock()
+	defer fake.deleteBrokersByFieldQueryMutex.RUnlock()
 	fake.deletePlatformMutex.RLock()
 	defer fake.deletePlatformMutex.RUnlock()
+	fake.deletePlatformsByFieldQueryMutex.RLock()
+	defer fake.deletePlatformsByFieldQueryMutex.RUnlock()
 	fake.deleteVisibilityMutex.RLock()
 	defer fake.deleteVisibilityMutex.RUnlock()
 	fake.getInfoMutex.RLock()

--- a/pkg/types/platform.go
+++ b/pkg/types/platform.go
@@ -24,9 +24,9 @@ import (
 // Platform defines the data of a platform.
 type Platform struct {
 	ID          string       `json:"id,omitempty" yaml:"id,omitempty"`
-	Name        string       `json:"name" yaml:"name"`
+	Name        string       `json:"name,omitempty" yaml:"name,omitempty"`
 	Description string       `json:"description,omitempty" yaml:"description,omitempty"`
-	Type        string       `json:"type" yaml:"type"`
+	Type        string       `json:"type,omitempty" yaml:"type,omitempty"`
 	Created     string       `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	Updated     string       `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 	Credentials *Credentials `json:"credentials,omitempty" yaml:"credentials,omitempty"`


### PR DESCRIPTION
## Motivation
SMCLI commands for update and delete platforms and brokers was developed before field querying.
Since field querying was introduces there is better solution for this commands and refactoring was needed.

## Approach
Update and delete commands work with names, and SM update and delete APIs work with IDs.
Before the approach was to list all brokers and then iterate over to find that brokers with names given for deletion. With field querying this could be achieved in a single call to SM. 

#### Pull Request status

- [x] Refactoring
- [x] Unit tests