### PR TITLE
Error handling on delete operations

### DIFF
--- a/internal/cmd/broker/delete_broker.go
+++ b/internal/cmd/broker/delete_broker.go
@@ -19,7 +19,9 @@ package broker
 import (
 	"fmt"
 	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/Peripli/service-manager-cli/pkg/errors"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/Peripli/service-manager-cli/internal/util"
@@ -64,8 +66,9 @@ func (dbc *DeleteBrokerCmd) Validate(args []string) error {
 func (dbc *DeleteBrokerCmd) Run() error {
 	fieldQuery := util.GetResourceByNamesQuery(dbc.names)
 	err := dbc.Client.DeleteBrokersByFieldQuery(fieldQuery)
-	if err != nil {
-		output.PrintMessage(dbc.Output, "Could not delete broker(s). Reason: ")
+	if respErr, ok := err.(errors.ResponseError); ok && respErr.StatusCode == http.StatusNotFound{
+		output.PrintMessage(dbc.Output, "Service Broker(s) not found.\n")
+	} else if err != nil {
 		return err
 	}
 	output.PrintMessage(dbc.Output, "Service Broker(s) successfully deleted.\n")

--- a/internal/cmd/broker/delete_broker.go
+++ b/internal/cmd/broker/delete_broker.go
@@ -69,6 +69,7 @@ func (dbc *DeleteBrokerCmd) Run() error {
 	if respErr, ok := err.(errors.ResponseError); ok && respErr.StatusCode == http.StatusNotFound{
 		output.PrintMessage(dbc.Output, "Service Broker(s) not found.\n")
 	} else if err != nil {
+		output.PrintMessage(dbc.Output, "Could not delete broker(s). Reason: ")
 		return err
 	}
 	output.PrintMessage(dbc.Output, "Service Broker(s) successfully deleted.\n")

--- a/internal/cmd/broker/delete_broker_test.go
+++ b/internal/cmd/broker/delete_broker_test.go
@@ -76,14 +76,25 @@ var _ = Describe("Delete brokers command test", func() {
 	})
 
 	Context("when non-existing brokers are being deleted", func() {
-		It("should return error message", func() {
+		It("should return message", func() {
 			expectedError := errors.ResponseError{StatusCode: http.StatusNotFound}
-			client.ListBrokersWithQueryReturns(&types.Brokers{}, nil)
 			client.DeleteBrokersByFieldQueryReturns(expectedError)
 			err := executeWithArgs([]string{"non-existing-name", "-f"})
 
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring("Service Broker(s) not found"))
+		})
+	})
+
+	Context("when SM returns error", func() {
+		It("should return error message", func() {
+			expectedError := errors.ResponseError{StatusCode: http.StatusInternalServerError}
+			client.DeleteBrokersByFieldQueryReturns(expectedError)
+			err := executeWithArgs([]string{"name", "-f"})
+
+			Expect(err).Should(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Could not delete broker(s). Reason:"))
+
 		})
 	})
 

--- a/internal/cmd/broker/delete_broker_test.go
+++ b/internal/cmd/broker/delete_broker_test.go
@@ -82,8 +82,8 @@ var _ = Describe("Delete brokers command test", func() {
 			client.DeleteBrokersByFieldQueryReturns(expectedError)
 			err := executeWithArgs([]string{"non-existing-name", "-f"})
 
-			Expect(err).Should(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Could not delete broker(s)."))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Service Broker(s) not found"))
 		})
 	})
 

--- a/internal/cmd/platform/delete_platform.go
+++ b/internal/cmd/platform/delete_platform.go
@@ -18,7 +18,9 @@ package platform
 
 import (
 	"fmt"
+	"github.com/Peripli/service-manager-cli/pkg/errors"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/Peripli/service-manager-cli/internal/output"
@@ -59,8 +61,9 @@ func (dpc *DeletePlatformCmd) Validate(args []string) error {
 func (dpc *DeletePlatformCmd) Run() error {
 	fieldQuery := util.GetResourceByNamesQuery(dpc.names)
 	err := dpc.Client.DeletePlatformsByFieldQuery(fieldQuery)
-	if err != nil {
-		output.PrintMessage(dpc.Output, "Could not delete platform(s). Reason: ")
+	if respErr, ok := err.(errors.ResponseError); ok && respErr.StatusCode == http.StatusNotFound{
+		output.PrintMessage(dpc.Output, "Platform(s) not found.\n")
+	} else if err != nil {
 		return err
 	}
 	output.PrintMessage(dpc.Output, "Platform(s) successfully deleted.\n")

--- a/internal/cmd/platform/delete_platform.go
+++ b/internal/cmd/platform/delete_platform.go
@@ -64,6 +64,7 @@ func (dpc *DeletePlatformCmd) Run() error {
 	if respErr, ok := err.(errors.ResponseError); ok && respErr.StatusCode == http.StatusNotFound{
 		output.PrintMessage(dpc.Output, "Platform(s) not found.\n")
 	} else if err != nil {
+		output.PrintMessage(dpc.Output, "Could not delete platform(s). Reason: ")
 		return err
 	}
 	output.PrintMessage(dpc.Output, "Platform(s) successfully deleted.\n")

--- a/internal/cmd/platform/delete_platform_test.go
+++ b/internal/cmd/platform/delete_platform_test.go
@@ -83,8 +83,8 @@ var _ = Describe("Delete platforms command test", func() {
 			client.DeletePlatformsByFieldQueryReturns(expectedError)
 			err := executeWithArgs([]string{"non-existing-name", "-f"})
 
-			Expect(err).Should(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("Could not delete platform(s)."))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Platform(s) not found."))
 		})
 	})
 

--- a/internal/cmd/platform/delete_platform_test.go
+++ b/internal/cmd/platform/delete_platform_test.go
@@ -77,14 +77,25 @@ var _ = Describe("Delete platforms command test", func() {
 	})
 
 	Context("when non-existing platform is being deleted", func() {
-		It("should return error message", func() {
+		It("should return message", func() {
 			expectedError := errors.ResponseError{StatusCode: http.StatusNotFound}
-			client.ListPlatformsWithQueryReturns(&types.Platforms{}, nil)
 			client.DeletePlatformsByFieldQueryReturns(expectedError)
 			err := executeWithArgs([]string{"non-existing-name", "-f"})
 
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buffer.String()).To(ContainSubstring("Platform(s) not found."))
+		})
+	})
+
+	Context("when SM returns error", func() {
+		It("should return error message", func() {
+			expectedError := errors.ResponseError{StatusCode: http.StatusInternalServerError}
+			client.DeletePlatformsByFieldQueryReturns(expectedError)
+			err := executeWithArgs([]string{"name", "-f"})
+
+			Expect(err).Should(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("Could not delete platform(s). Reason:"))
+
 		})
 	})
 


### PR DESCRIPTION
## Motivation
SM CLI returns error when all resources given for deletion are not found. This must not be considered as a failed command.

## Approach
Check if the response is 404 Not Found and print appropriate message, but not fail the command with and error.