### PR TITLE
Run dep ensure with -v to prevent build job timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 
 before_install:
   - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure
+  - dep ensure -v
 
 install:
   - go get github.com/onsi/gomega


### PR DESCRIPTION
Travis build job times out if there is no output for 10m
This happens sometimes during `dep ensure`