### PR TITLE
Fix manual installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ To use the Service Manager CLI you need to download and install it first:
 
 #### Install CLI
 
-``go install github.com/Peripli/service-manager-cli/smctl``
+``go install github.com/Peripli/service-manager-cli``
+
+#### Rename the CLI binary
+
+``mv $GOPATH/bin/service-manager-cli $GOPATH/bin/smctl``
 
 #### Use CLI
 


### PR DESCRIPTION
# Fix manual installation guide

## Motivation
The current manual installation guide is outdated.

https://github.com/Peripli/service-manager-cli/issues/52

## Approach
Updated the manual installation guide.
