### PR TITLE
Introduce list service instances command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,20 +21,29 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:f473f27517c12a44735d6f3a1cb56cdbfe7ae4a00f7c90a7bafac909a52c9699"
+  branch = "async_phase1"
+  digest = "1:4a2069ec4c891570e2c5079e8c40196929df778fd916ef4a4726174437b8e044"
   name = "github.com/Peripli/service-manager"
   packages = [
     "pkg/health",
     "pkg/log",
     "pkg/query",
+    "pkg/query/parser",
     "pkg/types",
     "pkg/util",
     "pkg/util/slice",
     "pkg/web",
   ]
   pruneopts = "UT"
-  revision = "a65c420ae21f1626cadef6f967a204335f69b645"
+  revision = "ee42b122ddacba5007f6c25a2fe49c575fb5a71c"
+
+[[projects]]
+  digest = "1:d04889482897652dedae6d8575b479c06fa3eb3c3abe248163b25d3df5fab43e"
+  name = "github.com/antlr/antlr4"
+  packages = ["runtime/Go/antlr"]
+  pruneopts = "UT"
+  revision = "be58ebffde8e29c154192c019608f0a5b8e6a064"
+  version = "4.7.2"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -151,7 +160,7 @@
   version = "v0.4.1"
 
 [[projects]]
-  digest = "1:264ad793409edc174dc6c54b8049835d182c634e0ffa700854dde98f6d23e67f"
+  digest = "1:e8b90ccda83af6f29b677f8b01a0be6721ab974c9f57d2f13b6149e478dfb4ec"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -175,11 +184,11 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "72b6ab036f78c4bf1a9748c3941dd7c3de54917a"
-  version = "v1.10.2"
+  revision = "ce5d301e555bb672c693c099ba6ca5087b06c0b4"
+  version = "v1.10.3"
 
 [[projects]]
-  digest = "1:5a9c247f0da47393b38eb20b53077be9e25452d8b2de1fdfec857233a18c503c"
+  digest = "1:7e57cd10c5424b2abf91f29354796a2468720396419585fef5a2d346c5a0f24d"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -196,16 +205,16 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "bdebf9e0ece900259084cfa4121b97ce1a540939"
-  version = "v1.7.0"
+  revision = "f9a52764bd5a0fd2d201bcca584351d03b72f8da"
+  version = "v1.7.1"
 
 [[projects]]
-  digest = "1:bbd3997f0121200f72b64d7a3826eb8a0b910d6a4c19894c9fe2852b9e5eaf3b"
+  digest = "1:6eea828983c70075ca297bb915ffbcfd3e34c5a50affd94428a65df955c0ff9c"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8fe62057ea2d46ce44254c98e84e810044dbe197"
-  version = "v1.5.0"
+  revision = "903d9455db9ff1d7ac1ab199062eca7266dd11a3"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:fd61cf4ae1953d55df708acb6b91492d538f49c305b364a014049914495db426"
@@ -259,20 +268,28 @@
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:11118bd196646c6515fea3d6c43f66162833c6ae4939bfb229b9956d91c6cf17"
+  digest = "1:0b60fc944fb6a7b6c985832bd341bdb7ed8fe894fea330414e7774bb24652962"
   name = "github.com/spf13/viper"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b5bf975e5823809fb22c7644d008757f78a4259e"
-  version = "v1.4.0"
+  revision = "72b022eb357a56469725dcd03918449e2278d02e"
+  version = "v1.5.0"
 
 [[projects]]
-  digest = "1:46aea6ffe39c3d95c13640c2515236ed3c5cdffc3c78c6c0ed4edec2caf7a0dc"
+  digest = "1:f4b32291cad5efac2bfdba89ccde6aa04618b62ce06c1a571da2dc4f3f2677fb"
+  name = "github.com/subosito/gotenv"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2ef7124db659d49edac6aa459693a15ae36c671a"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:719b772d0c56bbf1acd3a748f88b9d02ff6da543994b5d7e1adf052eb5b693a1"
   name = "github.com/tidwall/gjson"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c5e72cdf74dff23857243dd662c465b810891c21"
-  version = "v1.3.2"
+  revision = "5c2e4b382486589dad7478130a364ee2fa6a068b"
+  version = "v1.3.5"
 
 [[projects]]
   digest = "1:8453ddbed197809ee8ca28b06bd04e127bec9912deb4ba451fea7a1eca578328"
@@ -296,11 +313,11 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "87dc89f01550277dc22b74ffcf4cd89fa2f40f4c"
+  revision = "ac88ee75c92c889b97e05591e9a39b6480c538b3"
 
 [[projects]]
   branch = "master"
-  digest = "1:8c17b5bd24b2cd05fc3023018b52781aebf84244de6692aa7755a3ad03d47766"
+  digest = "1:54b4b9bc4be8560c3c1849569a2e75a0fe30c7c77b45f2e96f76df6dbbf04bb6"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -310,7 +327,7 @@
     "html/charset",
   ]
   pruneopts = "UT"
-  revision = "da9a3fd4c5820e74b24a6cb7fb438dc9b0dd377c"
+  revision = "ffdde105785063a81acd95bdf89ea53f6e0aac2d"
 
 [[projects]]
   branch = "master"
@@ -322,18 +339,18 @@
     "internal",
   ]
   pruneopts = "UT"
-  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+  revision = "5d9234df094ce600ff541158d1491aa10d078a47"
 
 [[projects]]
   branch = "master"
-  digest = "1:9f5be1dbb5091bb62d83fbb6db8e794adb8f0e05424679d6f15a17b670e38b4c"
+  digest = "1:adc8dbdd1348594585d83239cf52498fd87e103577dda9b50ccac2122d9ead72"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "b09406accb4736d857a32bf9444cd7edae2ffa79"
+  revision = "bd437916bb0eb726b873ee8e9b2dcf212d32e2fd"
 
 [[projects]]
   digest = "1:7570a3e4daa14b7627089e77ad8c714f5f36b4cf1b7dfd8510df7d6935dc42a0"
@@ -400,12 +417,12 @@
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
-  digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
+  digest = "1:b75b3deb2bce8bc079e16bb2aecfe01eb80098f5650f9e93e5643ca8b7b73737"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
-  version = "v2.2.4"
+  revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
+  version = "v2.2.7"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,8 +21,8 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "async_phase1"
-  digest = "1:4a2069ec4c891570e2c5079e8c40196929df778fd916ef4a4726174437b8e044"
+  branch = "master"
+  digest = "1:1ca1b1cbc5aca3022e4ff124fd4f9d3599b25cf3c46f6d0c43fa9386d3ab9eda"
   name = "github.com/Peripli/service-manager"
   packages = [
     "pkg/health",
@@ -35,7 +35,7 @@
     "pkg/web",
   ]
   pruneopts = "UT"
-  revision = "ee42b122ddacba5007f6c25a2fe49c575fb5a71c"
+  revision = "b6a3b7004a04a8bf0c46dacb61cfe9c9b15347e9"
 
 [[projects]]
   digest = "1:d04889482897652dedae6d8575b479c06fa3eb3c3abe248163b25d3df5fab43e"
@@ -313,7 +313,7 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "ac88ee75c92c889b97e05591e9a39b6480c538b3"
+  revision = "86a70503ff7e82ffc18c7b0de83db35da4791e6a"
 
 [[projects]]
   branch = "master"
@@ -327,11 +327,11 @@
     "html/charset",
   ]
   pruneopts = "UT"
-  revision = "ffdde105785063a81acd95bdf89ea53f6e0aac2d"
+  revision = "ef20fe5d793301b553005db740f730d87993f778"
 
 [[projects]]
   branch = "master"
-  digest = "1:457f9784b7d0402c051d4af2aa29b9ac602129801b0e4a643006d294f40775ec"
+  digest = "1:d6cd171816957f16fe559d9365073b79cb9bee957fb331ec19f1e1329858b944"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -339,18 +339,18 @@
     "internal",
   ]
   pruneopts = "UT"
-  revision = "5d9234df094ce600ff541158d1491aa10d078a47"
+  revision = "858c2ad4c8b6c5d10852cb89079f6ca1c7309787"
 
 [[projects]]
   branch = "master"
-  digest = "1:adc8dbdd1348594585d83239cf52498fd87e103577dda9b50ccac2122d9ead72"
+  digest = "1:77b59f879b437f66aa2d510e2752017a5a1ce3cef6f4744586affbed1ccf2f46"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "bd437916bb0eb726b873ee8e9b2dcf212d32e2fd"
+  revision = "6d18c012aee9febd81bbf9806760c8c4480e870d"
 
 [[projects]]
   digest = "1:7570a3e4daa14b7627089e77ad8c714f5f36b4cf1b7dfd8510df7d6935dc42a0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  branch = "async_phase1"
+  branch = "master"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  branch = "master"
+  branch = "async_phase1"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -20,13 +20,13 @@ login, l
     <code>--help</code> (alias: <code>-h</code>)
   </p>
   <p>
-    Help for <i>login</i> command. 
+    Help for <i>login</i> command.
   </p>
 </details>
 <details>
   <summary>password</summary>
   <p>
-    <code>--passowrd</code> (alias: <code>-p</code>)
+    <code>--password</code> (alias: <code>-p</code>)
   </p>
   <p>
     User password.
@@ -64,7 +64,7 @@ login, l
 <details>
   <summary>config</summary>
   <p>
-    <code>--config</code> 
+    <code>--config</code>
   </p>
   <p>
     Set the path for the <b>smctl</b> <i>config.json</i> file (default is <i>$HOME/.sm/config.json</i>)
@@ -85,7 +85,7 @@ login, l
 > smctl login -a https://service-manager-url.com
 
 User: user                # entering username
-Passowrd:                 # entering passowrd (password visibility is disabled)
+Password:                 # entering password (password visibility is disabled)
 Logged in successfully.
 ```
 

--- a/docs/commands/register-broker.md
+++ b/docs/commands/register-broker.md
@@ -10,7 +10,7 @@ smctl register-broker [name] [url] <description> [flags]
 
 ## Aliases
 ```bash
-register-broker, rb 
+register-broker, rb
 ```
 
 ## Flags
@@ -20,7 +20,7 @@ register-broker, rb
     <code>--help</code> (alias: <code>-h</code>)
   </p>
   <p>
-    Help for <i>register-broker</i> command. 
+    Help for <i>register-broker</i> command.
   </p>
 </details>
 <details>
@@ -29,7 +29,7 @@ register-broker, rb
     <code>--basic</code> (alias: <code>-b</code>)
   </p>
   <p>
-    Sets the username and password for basic authentication. Format is <i>&lt;username:passowrd&gt;</i>
+    Sets the username and password for basic authentication. Format is <i>&lt;username:password&gt;</i>
   </p>
 </details>
 <details>
@@ -46,7 +46,7 @@ register-broker, rb
 <details>
   <summary>config</summary>
   <p>
-    <code>--config</code> 
+    <code>--config</code>
   </p>
   <p>
     Set the path for the <b>smctl</b> <i>config.json</i> file (default is <i>$HOME/.sm/config.json</i>)
@@ -66,7 +66,7 @@ register-broker, rb
 ```bash
 > smctl register-broker sample-broker-1 https://demobroker.domain.com/ "Service broker providing some valuable services" -b user:pass
 
-ID                                    Name             URL                             Description                                      Created               Updated               
-------------------------------------  ---------------  ------------------------------  -----------------------------------------------  --------------------  --------------------  
+ID                                    Name             URL                             Description                                      Created               Updated
+------------------------------------  ---------------  ------------------------------  -----------------------------------------------  --------------------  --------------------
 a52be735-30e5-4849-af23-83d65d592464  sample-broker-1  https://demobroker.domain.com/  Service broker providing some valuable services  2018-06-22T13:04:19Z  2018-06-22T13:04:19Z
 ```

--- a/internal/cmd/instance/list_instances.go
+++ b/internal/cmd/instance/list_instances.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package instance
+
+import (
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// ListInstancesCmd wraps the smctl list-instances command
+type ListInstancesCmd struct {
+	*cmd.Context
+
+	outputFormat output.Format
+}
+
+// NewListInstancesCmd returns new list-instances command with context
+func NewListInstancesCmd(context *cmd.Context) *ListInstancesCmd {
+	return &ListInstancesCmd{Context: context}
+}
+
+// Run runs the command's logic
+func (li *ListInstancesCmd) Run() error {
+	instances, err := li.Client.ListInstances(&li.Parameters)
+	if err != nil {
+		return err
+	}
+
+	output.PrintServiceManagerObject(li.Output, li.outputFormat, instances)
+	output.Println(li.Output)
+
+	return nil
+}
+
+// SetOutputFormat sets output format
+func (li *ListInstancesCmd) SetOutputFormat(format output.Format) {
+	li.outputFormat = format
+}
+
+// HideUsage hides command's usage
+func (li *ListInstancesCmd) HideUsage() bool {
+	return true
+}
+
+// Prepare returns cobra command
+func (li *ListInstancesCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		Use:     "list-instances",
+		Aliases: []string{"li"},
+		Short:   "List service-instances",
+		Long:    `List all service-instances.`,
+		PreRunE: prepare(li, li.Context),
+		RunE:    cmd.RunE(li),
+	}
+
+	cmd.AddFormatFlag(result.Flags())
+	cmd.AddQueryingFlags(result.Flags(), &li.Parameters)
+	cmd.AddCommonQueryFlag(result.Flags(), &li.Parameters)
+
+	return result
+}

--- a/internal/cmd/instance/list_instances_test.go
+++ b/internal/cmd/instance/list_instances_test.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package instance
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	"gopkg.in/yaml.v2"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestListInstancesCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("List instances command test", func() {
+
+	var client *smclientfakes.FakeClient
+	var command *ListInstancesCmd
+	var buffer *bytes.Buffer
+
+	instance1 := types.ServiceInstance{
+		ID:            "id1",
+		Name:          "instance1",
+		ServicePlanID: "service_plan_id1",
+		PlatformID:    "platform_id1",
+	}
+
+	instance2 := types.ServiceInstance{
+		ID:            "id2",
+		Name:          "instance2",
+		ServicePlanID: "service_plan_id2",
+		PlatformID:    "platform_id2",
+	}
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		client = &smclientfakes.FakeClient{}
+		context := &cmd.Context{Output: buffer, Client: client}
+		command = NewListInstancesCmd(context)
+	})
+
+	executeWithArgs := func(args []string) error {
+		commandToRun := command.Prepare(cmd.SmPrepare)
+		commandToRun.SetArgs(args)
+
+		return commandToRun.Execute()
+	}
+
+	Context("when no instances are registered", func() {
+		It("should list empty instances", func() {
+			client.ListInstancesReturns(&types.ServiceInstances{ServiceInstances: []types.ServiceInstance{}}, nil)
+			err := executeWithArgs([]string{})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("There are no service instances."))
+		})
+	})
+
+	Context("when instances are registered", func() {
+		It("should list 1 instance", func() {
+			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance1}}
+			client.ListInstancesReturns(result, nil)
+			err := executeWithArgs([]string{})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(result.TableData().String()))
+		})
+
+		It("should list more instances", func() {
+			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance1, instance2}}
+			client.ListInstancesReturns(result, nil)
+			err := executeWithArgs([]string{})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(result.TableData().String()))
+		})
+	})
+
+	Context("when generic parameter is used", func() {
+		It("should pass it to SM", func() {
+			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance1}}
+			client.ListInstancesReturns(result, nil)
+			param := "parameterKey=parameterValue"
+			err := executeWithArgs([]string{"--param", param})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			args := client.ListInstancesArgsForCall(0)
+
+			Expect(args.GeneralParams).To(ConsistOf(param))
+			Expect(args.FieldQuery).To(BeEmpty())
+			Expect(args.LabelQuery).To(BeEmpty())
+		})
+	})
+
+	Context("when field query flag is used", func() {
+		It("should pass it to SM", func() {
+			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance1}}
+			client.ListInstancesReturns(result, nil)
+			param := "name eq 'instance1'"
+			err := executeWithArgs([]string{"--field-query", param})
+
+			args := client.ListInstancesArgsForCall(0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(args.FieldQuery).To(ConsistOf(param))
+			Expect(args.LabelQuery).To(BeEmpty())
+		})
+	})
+
+	Context("when label query flag is used", func() {
+		It("should pass it to SM", func() {
+			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance1}}
+			client.ListInstancesReturns(result, nil)
+			param := "test eq false"
+			err := executeWithArgs([]string{"--label-query", param})
+
+			args := client.ListInstancesArgsForCall(0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(args.FieldQuery).To(BeEmpty())
+			Expect(args.LabelQuery).To(ConsistOf(param))
+		})
+	})
+
+	Context("when format flag is used", func() {
+		It("should print in json", func() {
+			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance1}}
+			client.ListInstancesReturns(result, nil)
+
+			err := executeWithArgs([]string{"-o", "json"})
+
+			jsonByte, _ := json.MarshalIndent(result, "", "  ")
+			jsonOutputExpected := string(jsonByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
+		})
+
+		It("should print in yaml", func() {
+			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance1}}
+			client.ListInstancesReturns(result, nil)
+
+			err := executeWithArgs([]string{"-o", "yaml"})
+
+			yamlByte, _ := yaml.Marshal(result)
+			yamlOutputExpected := string(yamlByte) + "\n"
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
+		})
+	})
+
+	Context("when invalid flag is used", func() {
+		It("should handle cobra error", func() {
+			err := executeWithArgs([]string{"--ooutput", "json"})
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("unknown flag: --ooutput"))
+		})
+
+		It("should handle wrong value", func() {
+			err := executeWithArgs([]string{"--output", "invalid"})
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("unknown output: invalid"))
+		})
+	})
+
+	Context("when error is returned by Service manager", func() {
+		It("should handle error", func() {
+			expectedErr := errors.New("Http Client Error")
+			client.ListInstancesReturns(nil, expectedErr)
+			err := executeWithArgs([]string{})
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError(expectedErr))
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Peripli/service-manager-cli/internal/cmd/broker"
 	"github.com/Peripli/service-manager-cli/internal/cmd/curl"
 	"github.com/Peripli/service-manager-cli/internal/cmd/info"
+	"github.com/Peripli/service-manager-cli/internal/cmd/instance"
 	"github.com/Peripli/service-manager-cli/internal/cmd/label"
 	"github.com/Peripli/service-manager-cli/internal/cmd/login"
 	"github.com/Peripli/service-manager-cli/internal/cmd/offering"
@@ -73,6 +74,7 @@ func main() {
 			offering.NewMarketplaceCmd(context),
 			plan.NewListPlansCmd(context),
 			label.NewLabelCmd(context),
+			instance.NewListInstancesCmd(context),
 		},
 		PrepareFn: cmd.SmPrepare,
 	}

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -58,6 +58,8 @@ type Client interface {
 	UpdateVisibility(string, *types.Visibility, *query.Parameters) (*types.Visibility, error)
 	DeleteVisibilities(*query.Parameters) error
 
+	ListInstances(*query.Parameters) (*types.ServiceInstances, error)
+
 	Label(string, string, *types.LabelChanges, *query.Parameters) error
 
 	Marketplace(*query.Parameters) (*types.Marketplace, error)
@@ -211,10 +213,20 @@ func (client *serviceManagerClient) ListPlans(q *query.Parameters) (*types.Servi
 	return plans, err
 }
 
+// ListVisibilities returns visibilities registered in the Service Manager satisfying provided queries
 func (client *serviceManagerClient) ListVisibilities(q *query.Parameters) (*types.Visibilities, error) {
 	visibilities := &types.Visibilities{}
 	err := client.list(&visibilities.Visibilities, web.VisibilitiesURL, q)
+
 	return visibilities, err
+}
+
+// ListInstances returns service instances registered in the Service Manager satisfying provided queries
+func (client *serviceManagerClient) ListInstances(q *query.Parameters) (*types.ServiceInstances, error) {
+	instances := &types.ServiceInstances{}
+	err := client.list(&instances.ServiceInstances, web.ServiceInstancesURL, q)
+
+	return instances, err
 }
 
 // Marketplace returns service offerings satisfying provided queries

--- a/pkg/smclient/client_test.go
+++ b/pkg/smclient/client_test.go
@@ -91,6 +91,13 @@ var _ = Describe("Service Manager Client test", func() {
 		ServicePlanID: "planID",
 	}
 
+	instance := &types.ServiceInstance{
+		ID:            "instanceID",
+		Name:          "instance1",
+		ServicePlanID: "service_plan_id",
+		PlatformID:    "platform_id",
+	}
+
 	labelChanges := &types.LabelChanges{
 		LabelChanges: []*query.LabelChange{
 			{Key: "key", Operation: query.LabelOperation("add"), Values: []string{"val1", "val2"}},
@@ -490,7 +497,7 @@ var _ = Describe("Service Manager Client test", func() {
 					{Method: http.MethodGet, Path: web.ServiceBrokersURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
-			It("should return empty array", func() {
+			It("should return an empty array", func() {
 				result, err := client.ListBrokers(params)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(result.Brokers).To(HaveLen(0))
@@ -554,7 +561,7 @@ var _ = Describe("Service Manager Client test", func() {
 					{Method: http.MethodGet, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
-			It("should return empty array", func() {
+			It("should return an empty array", func() {
 				result, err := client.ListPlatforms(params)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(result.Platforms).To(HaveLen(0))
@@ -616,7 +623,7 @@ var _ = Describe("Service Manager Client test", func() {
 					{Method: http.MethodGet, Path: web.VisibilitiesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
-			It("should return empty array", func() {
+			It("should return an empty array", func() {
 				result, err := client.ListVisibilities(params)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(result.Visibilities).To(HaveLen(0))
@@ -644,6 +651,69 @@ var _ = Describe("Service Manager Client test", func() {
 			})
 			It("should handle status code > 299", func() {
 				_, err := client.ListVisibilities(params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+			})
+		})
+	})
+
+	Describe("List service instances", func() {
+		Context("when there are service instances registered", func() {
+			BeforeEach(func() {
+				instancesArray := []types.ServiceInstance{*instance}
+				instances := types.ServiceInstances{ServiceInstances: instancesArray}
+				responseBody, _ := json.Marshal(instances)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.ServiceInstancesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return all", func() {
+				result, err := client.ListInstances(params)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.ServiceInstances).To(HaveLen(1))
+				Expect(result.ServiceInstances[0]).To(Equal(*instance))
+			})
+		})
+
+		Context("when there are no service instances registered", func() {
+			BeforeEach(func() {
+				instancesArray := []types.ServiceInstance{}
+				instances := types.ServiceInstances{ServiceInstances: instancesArray}
+				responseBody, _ := json.Marshal(instances)
+
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.ServiceInstancesURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return an empty array", func() {
+				result, err := client.ListInstances(params)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.ServiceInstances).To(HaveLen(0))
+			})
+		})
+
+		Context("when invalid status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.ServiceInstancesURL, ResponseStatusCode: http.StatusCreated},
+				}
+			})
+			It("should handle status code != 200", func() {
+				_, err := client.ListInstances(params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+			})
+		})
+
+		Context("when invalid status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet, Path: web.ServiceInstancesURL, ResponseStatusCode: http.StatusBadRequest},
+				}
+			})
+			It("should handle status code > 299", func() {
+				_, err := client.ListInstances(params)
 				Expect(err).Should(HaveOccurred())
 				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
 			})
@@ -684,7 +754,7 @@ var _ = Describe("Service Manager Client test", func() {
 					{Method: http.MethodGet, Path: web.ServiceOfferingsURL, ResponseBody: offeringResponseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
-			It("should return empty array", func() {
+			It("should return an empty array", func() {
 				result, err := client.Marketplace(params)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(result.ServiceOfferings).To(HaveLen(0))

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -101,6 +101,19 @@ type FakeClient struct {
 		result1 *types.Brokers
 		result2 error
 	}
+	ListInstancesStub        func(*query.Parameters) (*types.ServiceInstances, error)
+	listInstancesMutex       sync.RWMutex
+	listInstancesArgsForCall []struct {
+		arg1 *query.Parameters
+	}
+	listInstancesReturns struct {
+		result1 *types.ServiceInstances
+		result2 error
+	}
+	listInstancesReturnsOnCall map[int]struct {
+		result1 *types.ServiceInstances
+		result2 error
+	}
 	ListOfferingsStub        func(*query.Parameters) (*types.ServiceOfferings, error)
 	listOfferingsMutex       sync.RWMutex
 	listOfferingsArgsForCall []struct {
@@ -688,6 +701,69 @@ func (fake *FakeClient) ListBrokersReturnsOnCall(i int, result1 *types.Brokers, 
 	}
 	fake.listBrokersReturnsOnCall[i] = struct {
 		result1 *types.Brokers
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListInstances(arg1 *query.Parameters) (*types.ServiceInstances, error) {
+	fake.listInstancesMutex.Lock()
+	ret, specificReturn := fake.listInstancesReturnsOnCall[len(fake.listInstancesArgsForCall)]
+	fake.listInstancesArgsForCall = append(fake.listInstancesArgsForCall, struct {
+		arg1 *query.Parameters
+	}{arg1})
+	fake.recordInvocation("ListInstances", []interface{}{arg1})
+	fake.listInstancesMutex.Unlock()
+	if fake.ListInstancesStub != nil {
+		return fake.ListInstancesStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listInstancesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListInstancesCallCount() int {
+	fake.listInstancesMutex.RLock()
+	defer fake.listInstancesMutex.RUnlock()
+	return len(fake.listInstancesArgsForCall)
+}
+
+func (fake *FakeClient) ListInstancesCalls(stub func(*query.Parameters) (*types.ServiceInstances, error)) {
+	fake.listInstancesMutex.Lock()
+	defer fake.listInstancesMutex.Unlock()
+	fake.ListInstancesStub = stub
+}
+
+func (fake *FakeClient) ListInstancesArgsForCall(i int) *query.Parameters {
+	fake.listInstancesMutex.RLock()
+	defer fake.listInstancesMutex.RUnlock()
+	argsForCall := fake.listInstancesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) ListInstancesReturns(result1 *types.ServiceInstances, result2 error) {
+	fake.listInstancesMutex.Lock()
+	defer fake.listInstancesMutex.Unlock()
+	fake.ListInstancesStub = nil
+	fake.listInstancesReturns = struct {
+		result1 *types.ServiceInstances
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListInstancesReturnsOnCall(i int, result1 *types.ServiceInstances, result2 error) {
+	fake.listInstancesMutex.Lock()
+	defer fake.listInstancesMutex.Unlock()
+	fake.ListInstancesStub = nil
+	if fake.listInstancesReturnsOnCall == nil {
+		fake.listInstancesReturnsOnCall = make(map[int]struct {
+			result1 *types.ServiceInstances
+			result2 error
+		})
+	}
+	fake.listInstancesReturnsOnCall[i] = struct {
+		result1 *types.ServiceInstances
 		result2 error
 	}{result1, result2}
 }
@@ -1411,6 +1487,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.labelMutex.RUnlock()
 	fake.listBrokersMutex.RLock()
 	defer fake.listBrokersMutex.RUnlock()
+	fake.listInstancesMutex.RLock()
+	defer fake.listInstancesMutex.RUnlock()
 	fake.listOfferingsMutex.RLock()
 	defer fake.listOfferingsMutex.RUnlock()
 	fake.listPlansMutex.RLock()

--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Peripli/service-manager/pkg/types"
+	"strconv"
+)
+
+// ServiceInstance defines the data of a service instance.
+type ServiceInstance struct {
+	ID        string `json:"id,omitempty" yaml:"id,omitempty"`
+	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
+	CreatedAt string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+
+	Labels         types.Labels `json:"labels,omitempty" yaml:"labels,omitempty"`
+	PagingSequence int64        `json:"-" yaml:"-"`
+	ServicePlanID  string       `json:"service_plan_id,omitempty" yaml:"service_plan_id,omitempty"`
+	PlatformID     string       `json:"platform_id,omitempty" yaml:"platform_id,omitempty"`
+
+	MaintenanceInfo json.RawMessage `json:"maintenance_info,omitempty" yaml:"-"`
+	Context         json.RawMessage `json:"-" yaml:"-"`
+	PreviousValues  json.RawMessage `json:"-" yaml:"-"`
+
+	Ready  bool `json:"ready" yaml:"ready"`
+	Usable bool `json:"usable" yaml:"usable"`
+}
+
+// Message title of the table
+func (si *ServiceInstance) Message() string {
+	return ""
+}
+
+// IsEmpty whether the structure is empty
+func (si *ServiceInstance) IsEmpty() bool {
+	return false
+}
+
+// TableData returns the data to populate a table
+func (si *ServiceInstance) TableData() *TableData {
+	result := &TableData{}
+	result.Headers = []string{"ID", "Name", "Service Plan ID", "Platform ID", "Created", "Updated", "Ready", "Usable", "Labels"}
+
+	row := []string{si.ID, si.Name, si.ServicePlanID, si.PlatformID, si.CreatedAt, si.UpdatedAt, strconv.FormatBool(si.Ready), strconv.FormatBool(si.Usable), formatLabels(si.Labels)}
+	result.Data = append(result.Data, row)
+
+	return result
+}
+
+// ServiceInstances wraps an array of service instances
+type ServiceInstances struct {
+	ServiceInstances []ServiceInstance `json:"items" yaml:"items"`
+}
+
+// Message title of the table
+func (si *ServiceInstances) Message() string {
+	var msg string
+
+	if len(si.ServiceInstances) == 0 {
+		msg = "There are no service instances."
+	} else if len(si.ServiceInstances) == 1 {
+		msg = "One service instance."
+	} else {
+		msg = fmt.Sprintf("%d service instances.", len(si.ServiceInstances))
+	}
+
+	return msg
+}
+
+// IsEmpty whether the structure is empty
+func (si *ServiceInstances) IsEmpty() bool {
+	return len(si.ServiceInstances) == 0
+}
+
+// TableData returns the data to populate a table
+func (si *ServiceInstances) TableData() *TableData {
+	result := &TableData{}
+	result.Headers = []string{"ID", "Name", "Service Plan ID", "Platform ID", "Created", "Updated", "Ready", "Usable", "Labels"}
+
+	for _, instance := range si.ServiceInstances {
+		row := []string{instance.ID, instance.Name, instance.ServicePlanID, instance.PlatformID, instance.CreatedAt, instance.UpdatedAt, strconv.FormatBool(instance.Ready), strconv.FormatBool(instance.Usable), formatLabels(instance.Labels)}
+		result.Data = append(result.Data, row)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Motivation
Service Manager provides API for listing Service Instances so the cli should be adapted.

## Approach
Introduced smctl list-instances (smctl li) command for listing service instances. Field, label and general query is supported as well.

#### Pull Request status
- [x] Initial implementation
- [x] Unit tests