### PR TITLE
Improve verobse output

### DIFF
--- a/internal/cmd/commander.go
+++ b/internal/cmd/commander.go
@@ -129,7 +129,7 @@ func SmPrepare(cmd Command, ctx *Context) func(*cobra.Command, []string) error {
 				}
 			}
 
-			ctx.Client = smclient.NewClient(oidcClient, settings.URL)
+			ctx.Client = smclient.NewClient(ctx.Ctx, oidcClient, settings.URL)
 		}
 
 		return nil

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"github.com/Peripli/service-manager-cli/pkg/query"
 	"io"
 
@@ -26,6 +27,8 @@ import (
 
 // Context is used as a context for the commands
 type Context struct {
+	Ctx context.Context
+
 	// Output should be used when printing in commands, instead of directly writing to stdout/stderr, to enable unit testing.
 	Output io.Writer
 

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -115,7 +115,7 @@ func (lc *Cmd) Run() error {
 	httpClient := util.BuildHTTPClient(lc.sslDisabled)
 
 	if lc.Client == nil {
-		lc.Client = smclient.NewClient(httpClient, lc.serviceManagerURL)
+		lc.Client = smclient.NewClient(lc.Ctx, httpClient, lc.serviceManagerURL)
 	}
 
 	info, err := lc.Client.GetInfo(&lc.Parameters)

--- a/internal/cmd/smctl.go
+++ b/internal/cmd/smctl.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -45,7 +44,8 @@ func BuildRootCommand(ctx *Context) *cobra.Command {
 		Long:  `smctl controls a Service Manager instance.`,
 
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := log.Configure(context.Background(), logSettings(ctx.Verbose)); err != nil {
+			var err error
+			if ctx.Ctx, err = log.Configure(ctx.Ctx, logSettings(ctx.Verbose)); err != nil {
 				return err
 			}
 			cmd.SilenceUsage = true

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 	"github.com/Peripli/service-manager-cli/internal/cmd/binding"
 	"github.com/Peripli/service-manager-cli/internal/cmd/broker"
@@ -44,48 +45,50 @@ func oidcAuthBuilder(options *auth.Options) (auth.Authenticator, *auth.Options, 
 }
 
 func main() {
-	context := &cmd.Context{}
-	rootCmd := cmd.BuildRootCommand(context)
+	cmdContext := &cmd.Context{
+		Ctx: context.Background(),
+	}
+	rootCmd := cmd.BuildRootCommand(cmdContext)
 	fs := afero.NewOsFs()
 
 	normalCommandsGroup := cmd.Group{
 		Commands: []cmd.CommandPreparator{
-			login.NewLoginCmd(context, os.Stdin, oidcAuthBuilder),
-			version.NewVersionCmd(context),
-			info.NewInfoCmd(context),
+			login.NewLoginCmd(cmdContext, os.Stdin, oidcAuthBuilder),
+			version.NewVersionCmd(cmdContext),
+			info.NewInfoCmd(cmdContext),
 		},
 		PrepareFn: cmd.CommonPrepare,
 	}
 
 	smCommandsGroup := cmd.Group{
 		Commands: []cmd.CommandPreparator{
-			curl.NewCurlCmd(context, fs),
-			binding.NewListBindingsCmd(context),
-			binding.NewGetBindingCmd(context),
-			binding.NewBindCmd(context),
-			binding.NewUnbindCmd(context, os.Stdin),
-			broker.NewRegisterBrokerCmd(context),
-			broker.NewGetBrokerCmd(context),
-			broker.NewListBrokersCmd(context),
-			broker.NewDeleteBrokerCmd(context, os.Stdin),
-			broker.NewUpdateBrokerCmd(context),
-			platform.NewRegisterPlatformCmd(context),
-			platform.NewListPlatformsCmd(context),
-			platform.NewDeletePlatformCmd(context, os.Stdin),
-			platform.NewUpdatePlatformCmd(context),
-			visibility.NewRegisterVisibilityCmd(context),
-			visibility.NewListVisibilitiesCmd(context),
-			visibility.NewUpdateVisibilityCmd(context),
-			visibility.NewDeleteVisibilityCmd(context, os.Stdin),
-			offering.NewListOfferingsCmd(context),
-			offering.NewMarketplaceCmd(context),
-			plan.NewListPlansCmd(context),
-			label.NewLabelCmd(context),
-			status.NewStatusCmd(context),
-			instance.NewListInstancesCmd(context),
-			instance.NewGetInstanceCmd(context),
-			instance.NewProvisionCmd(context),
-			instance.NewDeprovisionCmd(context, os.Stdin),
+			curl.NewCurlCmd(cmdContext, fs),
+			binding.NewListBindingsCmd(cmdContext),
+			binding.NewGetBindingCmd(cmdContext),
+			binding.NewBindCmd(cmdContext),
+			binding.NewUnbindCmd(cmdContext, os.Stdin),
+			broker.NewRegisterBrokerCmd(cmdContext),
+			broker.NewGetBrokerCmd(cmdContext),
+			broker.NewListBrokersCmd(cmdContext),
+			broker.NewDeleteBrokerCmd(cmdContext, os.Stdin),
+			broker.NewUpdateBrokerCmd(cmdContext),
+			platform.NewRegisterPlatformCmd(cmdContext),
+			platform.NewListPlatformsCmd(cmdContext),
+			platform.NewDeletePlatformCmd(cmdContext, os.Stdin),
+			platform.NewUpdatePlatformCmd(cmdContext),
+			visibility.NewRegisterVisibilityCmd(cmdContext),
+			visibility.NewListVisibilitiesCmd(cmdContext),
+			visibility.NewUpdateVisibilityCmd(cmdContext),
+			visibility.NewDeleteVisibilityCmd(cmdContext, os.Stdin),
+			offering.NewListOfferingsCmd(cmdContext),
+			offering.NewMarketplaceCmd(cmdContext),
+			plan.NewListPlansCmd(cmdContext),
+			label.NewLabelCmd(cmdContext),
+			status.NewStatusCmd(cmdContext),
+			instance.NewListInstancesCmd(cmdContext),
+			instance.NewGetInstanceCmd(cmdContext),
+			instance.NewProvisionCmd(cmdContext),
+			instance.NewDeprovisionCmd(cmdContext, os.Stdin),
 		},
 		PrepareFn: cmd.SmPrepare,
 	}

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/log"
 	"io"
 	"net/http"
 
@@ -82,6 +83,7 @@ type Client interface {
 }
 
 type serviceManagerClient struct {
+	ctx        context.Context
 	config     *ClientConfig
 	httpClient auth.Client
 }
@@ -121,8 +123,8 @@ func NewClientWithAuth(httpClient auth.Client, config *ClientConfig) (Client, er
 }
 
 // NewClient returns new SM client which will use the http client provided to make calls
-func NewClient(httpClient auth.Client, URL string) Client {
-	return &serviceManagerClient{config: &ClientConfig{URL: URL}, httpClient: httpClient}
+func NewClient(ctx context.Context, httpClient auth.Client, URL string) Client {
+	return &serviceManagerClient{ctx: ctx, config: &ClientConfig{URL: URL}, httpClient: httpClient}
 }
 
 func (client *serviceManagerClient) GetInfo(q *query.Parameters) (*types.Info, error) {
@@ -334,7 +336,7 @@ func (client *serviceManagerClient) Status(url string, q *query.Parameters) (*ty
 
 func (client *serviceManagerClient) list(result interface{}, url string, q *query.Parameters) error {
 	fullURL := httputil.NormalizeURL(client.config.URL) + BuildURL(url, q)
-	return util.ListAll(context.Background(), client.httpClient.Do, fullURL, result)
+	return util.ListAll(client.ctx, client.httpClient.Do, fullURL, result)
 }
 
 func (client *serviceManagerClient) get(result interface{}, url string, q *query.Parameters) error {
@@ -462,6 +464,7 @@ func (client *serviceManagerClient) Call(method string, smpath string, body io.R
 	}
 	req.Header.Add("Content-Type", "application/json")
 
+	log.C(client.ctx).Debugf("Sending request %s %s", req.Method, req.URL)
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/smclient/test/binding_test.go
+++ b/pkg/smclient/test/binding_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/Peripli/service-manager-cli/pkg/smclient"
 	"github.com/Peripli/service-manager/pkg/web"
@@ -243,7 +244,7 @@ var _ = Describe("Binding test", func() {
 
 		Context("When invalid config is set", func() {
 			It("should return error", func() {
-				client = smclient.NewClient(fakeAuthClient, "invalidURL")
+				client = smclient.NewClient(context.TODO(), fakeAuthClient, "invalidURL")
 				_, location, err := client.Bind(binding, params)
 
 				Expect(err).Should(HaveOccurred())

--- a/pkg/smclient/test/broker_test.go
+++ b/pkg/smclient/test/broker_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/Peripli/service-manager-cli/pkg/smclient"
@@ -243,7 +244,7 @@ var _ = Describe("Broker test", func() {
 
 		Context("When invalid config is set", func() {
 			It("should return error", func() {
-				client = smclient.NewClient(fakeAuthClient, "invalidURL")
+				client = smclient.NewClient(context.TODO(),fakeAuthClient, "invalidURL")
 				_, location, err := client.RegisterBroker(broker, params)
 
 				Expect(err).Should(HaveOccurred())

--- a/pkg/smclient/test/client_test.go
+++ b/pkg/smclient/test/client_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"github.com/Peripli/service-manager-cli/pkg/smclient"
 	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
@@ -20,7 +21,7 @@ var _ = Describe("SM Client test", func() {
 			})
 			It("should fail to authentication", func() {
 				fakeAuthClient.AccessToken = invalidToken
-				client = smclient.NewClient(fakeAuthClient, smServer.URL)
+				client = smclient.NewClient(context.TODO(), fakeAuthClient, smServer.URL)
 				_, err := client.ListBrokers(params)
 
 				Expect(err).Should(HaveOccurred())

--- a/pkg/smclient/test/instance_test.go
+++ b/pkg/smclient/test/instance_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/Peripli/service-manager-cli/pkg/smclient"
 	"net/http"
@@ -244,7 +245,7 @@ var _ = Describe("Instance test", func() {
 
 		Context("When invalid config is set", func() {
 			It("should return error", func() {
-				client = smclient.NewClient(fakeAuthClient, "invalidURL")
+				client = smclient.NewClient(context.TODO(),fakeAuthClient, "invalidURL")
 				_, location, err := client.Provision(instance, params)
 
 				Expect(err).Should(HaveOccurred())

--- a/pkg/smclient/test/label_test.go
+++ b/pkg/smclient/test/label_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"github.com/Peripli/service-manager-cli/pkg/smclient"
 	"net/http"
 
@@ -35,7 +36,7 @@ var _ = Describe("Label test", func() {
 
 	Context("When invalid config is set", func() {
 		It("should return error", func() {
-			client = smclient.NewClient(fakeAuthClient, "invalidURL")
+			client = smclient.NewClient(context.TODO(),fakeAuthClient, "invalidURL")
 			err := client.Label(web.ServiceBrokersURL, "id", labelChanges, params)
 			Expect(err).Should(HaveOccurred())
 		})

--- a/pkg/smclient/test/platform_test.go
+++ b/pkg/smclient/test/platform_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/Peripli/service-manager-cli/pkg/smclient"
 	"net/http"
@@ -170,7 +171,7 @@ var _ = Describe("Platform test", func() {
 
 		Context("When invalid config is set", func() {
 			It("should return error", func() {
-				client = smclient.NewClient(fakeAuthClient, "invalidURL")
+				client = smclient.NewClient(context.TODO(), fakeAuthClient, "invalidURL")
 				_, err := client.RegisterPlatform(platform, params)
 
 				Expect(err).Should(HaveOccurred())

--- a/pkg/smclient/test/smclient_suite_test.go
+++ b/pkg/smclient/test/smclient_suite_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -151,5 +152,5 @@ var _ = AfterEach(func() {
 var _ = JustBeforeEach(func() {
 	smServer = httptest.NewServer(createSMHandler())
 	fakeAuthClient = &FakeAuthClient{AccessToken: validToken}
-	client = smclient.NewClient(fakeAuthClient, smServer.URL)
+	client = smclient.NewClient(context.TODO(), fakeAuthClient, smServer.URL)
 })

--- a/pkg/smclient/test/visibility_test.go
+++ b/pkg/smclient/test/visibility_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/Peripli/service-manager-cli/pkg/smclient"
 	"github.com/Peripli/service-manager/pkg/web"
@@ -172,7 +173,7 @@ var _ = Describe("Visibility test", func() {
 
 		Context("When invalid config is set", func() {
 			It("should return error", func() {
-				client = smclient.NewClient(fakeAuthClient, "invalidURL")
+				client = smclient.NewClient(context.TODO(), fakeAuthClient, "invalidURL")
 				_, err := client.RegisterVisibility(visibility, params)
 
 				Expect(err).Should(HaveOccurred())


### PR DESCRIPTION
## Motivation
Previously `-v --verbose` flag was not doing anything. With this change the `-v` flag prints all calls to SM.

```
smctl get-broker test-broker-subacc-cfdev-tenant-id -v
DEBU[0000] Sending request GET http://localhost:8081/v1/service_brokers?fieldQuery=name+eq+%27test-broker-subacc-cfdev-tenant-id%27  component="util/client.go:87" correlation_id=-
DEBU[0000] Sending request GET http://localhost:8081/v1/service_brokers/507ba725-7554-4ead-b870-bb56cece92ad  component="smclient/client.go:467" correlation_id=-

| ID           | 507ba725-7554-4ead-b870-bb56cece92ad  |
| Name         | test-broker-subacc-cfdev-tenant-id    |
| URL          | http://sm-test-broker:8083            |
| Description  | asd                                   |
| Created      | 2020-04-06T13:06:26.965654Z           |
| Updated      | 2020-04-06T13:09:27.391246Z           |
| Labels       | subaccount_id=subacc-cfdev-tenant-id  |
| Last Op      | update succeeded                      |
```