### PR TITLE
Implement transfer-instance command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 # IDE specific
 .vscode/
 /.idea
+
+main

--- a/internal/cmd/instance/deprovision_test.go
+++ b/internal/cmd/instance/deprovision_test.go
@@ -1,9 +1,10 @@
 package instance
 
 import (
-	"github.com/Peripli/service-manager/pkg/util"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/util"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/internal/cmd/instance/transfer.go
+++ b/internal/cmd/instance/transfer.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package instance
+
+import (
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/Peripli/service-manager-cli/pkg/query"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// TransferCmd wraps the smctl provision command
+type TransferCmd struct {
+	*cmd.Context
+
+	instanceName   string
+	instanceID     string
+	fromPlatformID string
+	toPlatformID   string
+
+	outputFormat output.Format
+}
+
+// NewTransferCmd returns new transfer instance command with context
+func NewTransferCmd(context *cmd.Context) *TransferCmd {
+	return &TransferCmd{Context: context}
+}
+
+// Prepare returns cobra command
+func (trc *TransferCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		Use:   "transfer-instance [name]",
+		Short: "Transfer instance in one platform to another in SM",
+		Long:  `Transfer instance in one platform to another in SM`,
+
+		PreRunE: prepare(trc, trc.Context),
+		RunE:    cmd.RunE(trc),
+	}
+
+	result.Flags().StringVarP(&trc.instanceID, "id", "", "", "Id of the instance. Required in case when there are instances with same name")
+	result.Flags().StringVarP(&trc.fromPlatformID, "from", "", "", "ID of the platform from which you want to move the instance")
+	result.Flags().StringVarP(&trc.toPlatformID, "to", "", "", "ID of the platform to which you want to move the instance")
+	cmd.AddFormatFlag(result.Flags())
+	cmd.AddModeFlag(result.Flags(), "async")
+
+	return result
+}
+
+// Validate validates command's arguments
+func (trc *TransferCmd) Validate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("name is required")
+	}
+	trc.instanceName = args[0]
+
+	if len(trc.fromPlatformID) == 0 {
+		return fmt.Errorf("--from is required")
+	}
+
+	if len(trc.toPlatformID) == 0 {
+		return fmt.Errorf("--to is required")
+	}
+
+	return nil
+}
+
+// Run runs the command's logic
+func (trc *TransferCmd) Run() error {
+	var instance *types.ServiceInstance
+	instances, err := trc.Client.ListInstances(&query.Parameters{
+		FieldQuery: []string{
+			fmt.Sprintf("name eq '%s'", trc.instanceName),
+			fmt.Sprintf("platform_id eq '%s'", trc.fromPlatformID),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if len(instances.ServiceInstances) == 0 {
+		return fmt.Errorf("No instances found with name %s", trc.instanceName)
+	}
+
+	if len(instances.ServiceInstances) > 1 {
+		if len(trc.instanceID) == 0 {
+			return fmt.Errorf("More than 1 instance found with name %s. Use --id flag to specify one", trc.instanceName)
+		}
+		instance, err = trc.Client.GetInstanceByID(trc.instanceID, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		instance = &instances.ServiceInstances[0]
+	}
+
+	resultInstance, location, err := trc.Client.UpdateInstance(instance.ID, &types.ServiceInstance{
+		PlatformID: trc.toPlatformID,
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	if len(location) != 0 {
+		cmd.CommonHandleAsyncExecution(trc.Context, location, fmt.Sprintf("Service Instance %s successfully scheduled for transfer to platform with id %s. To see status of the operation use:\n", trc.instanceName, trc.toPlatformID))
+		return nil
+	}
+	output.PrintServiceManagerObject(trc.Output, trc.outputFormat, resultInstance)
+	output.Println(trc.Output)
+	return nil
+}
+
+// SetOutputFormat set output format
+func (trc *TransferCmd) SetOutputFormat(format output.Format) {
+	trc.outputFormat = format
+}
+
+// HideUsage hide command's usage
+func (trc *TransferCmd) HideUsage() bool {
+	return true
+}

--- a/internal/cmd/instance/transfer.go
+++ b/internal/cmd/instance/transfer.go
@@ -101,11 +101,11 @@ func (trc *TransferCmd) Run() error {
 			return err
 		}
 		if len(instances.ServiceInstances) == 0 {
-			return fmt.Errorf("No instances found with name %s", trc.instanceName)
+			return fmt.Errorf("no instances found with name %s", trc.instanceName)
 		}
 
 		if len(instances.ServiceInstances) > 1 {
-			return fmt.Errorf("More than 1 instance found with name %s. Use --id flag to specify one", trc.instanceName)
+			return fmt.Errorf("more than 1 instance found with name %s. Use --id flag to specify one", trc.instanceName)
 		}
 
 		trc.instanceID = instances.ServiceInstances[0].ID

--- a/internal/cmd/instance/transfer_test.go
+++ b/internal/cmd/instance/transfer_test.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package instance
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+var _ = Describe("Transfer Command test", func() {
+	var client *smclientfakes.FakeClient
+	var command *TransferCmd
+	var buffer *bytes.Buffer
+
+	var instance *types.ServiceInstance
+
+	validAsyncTransferExecution := func(location string, args ...string) *cobra.Command {
+		instance = &types.ServiceInstance{
+			Name: args[0],
+		}
+		operation := &types.Operation{
+			State: "in progress",
+		}
+		client.StatusReturns(operation, nil)
+		client.ListInstancesReturns(&types.ServiceInstances{ServiceInstances: []types.ServiceInstance{*instance}}, nil)
+		client.UpdateInstanceReturns(instance, location, nil)
+
+		piCmd := command.Prepare(cmd.SmPrepare)
+		piCmd.SetArgs(args)
+		Expect(piCmd.Execute()).ToNot(HaveOccurred())
+
+		return piCmd
+	}
+
+	validSyncTransferExecution := func(args ...string) *cobra.Command {
+		return validAsyncTransferExecution("", append(args, "--mode", "sync")...)
+	}
+
+	invalidTransferCommandExecution := func(args ...string) error {
+		trCmd := command.Prepare(cmd.SmPrepare)
+		trCmd.SetArgs(args)
+		return trCmd.Execute()
+	}
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		client = &smclientfakes.FakeClient{}
+		context := &cmd.Context{Output: buffer, Client: client}
+		command = NewTransferCmd(context)
+	})
+
+	Describe("Valid request", func() {
+		Context("With necessary arguments provided", func() {
+			It("should be transfered successfully", func() {
+				validSyncTransferExecution("instance-name", "--from", "platform_id", "--to", "service-manager")
+
+				tableOutputExpected := instance.TableData().String()
+
+				Expect(buffer.String()).To(ContainSubstring(tableOutputExpected))
+			})
+
+			It("should print location when transfered asynchronously", func() {
+				validAsyncTransferExecution("location", "instance-name", "--from", "platform_id", "--to", "service-manager")
+
+				Expect(buffer.String()).To(ContainSubstring(`smctl status location`))
+			})
+
+			It("Argument values should be as expected", func() {
+				validSyncTransferExecution("instance-name", "--from", "from_platform", "--to", "to_platform")
+
+				Expect(command.instanceName).To(Equal("instance-name"))
+				Expect(command.fromPlatformID).To(Equal("from_platform"))
+				Expect(command.toPlatformID).To(Equal("to_platform"))
+			})
+		})
+
+		Context("when 2 instances are present with same name", func() {
+			BeforeEach(func() {
+				client.ListInstancesReturnsOnCall(0, &types.ServiceInstances{
+					ServiceInstances: []types.ServiceInstance{
+						types.ServiceInstance{
+							Name: "instance-name",
+						},
+						types.ServiceInstance{
+							Name: "instance-name",
+						},
+					},
+				}, nil)
+
+				client.GetInstanceByIDReturns(&types.ServiceInstance{
+					Name: "instance-name",
+				}, nil)
+			})
+			Context("when no instance id is provided", func() {
+				It("should require flag for instance id", func() {
+					err := invalidTransferCommandExecution("instance-name", "--from", "from_platform", "--to", "to_platform")
+					Expect(err.Error()).To(Equal("More than 1 instance found with name instance-name. Use --id flag to specify one"))
+				})
+			})
+
+			Context("when instance id is provided", func() {
+				It("should transfer the specified instance id", func() {
+					validSyncTransferExecution("instance-name", "--from", "from_platform", "--to", "to_platform", "--id", "12345")
+					Expect(buffer.String()).To(ContainSubstring(instance.TableData().String()))
+				})
+			})
+		})
+
+		Context("when no instanes are present with certain name", func() {
+			BeforeEach(func() {
+				client.ListInstancesReturnsOnCall(0, &types.ServiceInstances{
+					ServiceInstances: []types.ServiceInstance{},
+				}, nil)
+			})
+
+			It("should fail to transfer", func() {
+				err := invalidTransferCommandExecution("no-instance", "--from", "from_platform", "--to", "to_platform")
+				Expect(err.Error()).To(Equal("No instances found with name no-instance"))
+			})
+		})
+
+		Context("With json output flag", func() {
+			It("should be printed in json output format", func() {
+				validSyncTransferExecution("instance-name", "--from", "from_platform", "--to", "to_platform", "--output", "json")
+
+				jsonByte, _ := json.MarshalIndent(instance, "", "  ")
+				jsonOutputExpected := string(jsonByte) + "\n"
+
+				Expect(buffer.String()).To(Equal(jsonOutputExpected))
+			})
+		})
+
+		Context("With yaml output flag", func() {
+			It("should be printed in yaml output format", func() {
+				validSyncTransferExecution("instance-name", "--from", "from_platform", "--to", "to_platform", "--output", "yaml")
+
+				yamlByte, _ := yaml.Marshal(instance)
+				yamlOutputExpected := string(yamlByte) + "\n"
+
+				Expect(buffer.String()).To(Equal(yamlOutputExpected))
+			})
+		})
+	})
+
+	Describe("Invalid requests", func() {
+		When("list instances fails", func() {
+			BeforeEach(func() {
+				client.ListInstancesReturns(nil, errors.New("errored"))
+			})
+
+			It("should return error", func() {
+				err := invalidTransferCommandExecution("instance-name", "--from", "from_platform", "--to", "to_platform")
+				Expect(err.Error()).To(Equal("errored"))
+			})
+		})
+
+		When("get instance fails", func() {
+			BeforeEach(func() {
+				client.ListInstancesReturnsOnCall(0, &types.ServiceInstances{
+					ServiceInstances: []types.ServiceInstance{
+						types.ServiceInstance{
+							Name: "instance-name",
+						},
+						types.ServiceInstance{
+							Name: "instance-name",
+						},
+					},
+				}, nil)
+
+				client.GetInstanceByIDReturns(nil, errors.New("errored"))
+			})
+
+			It("should return error", func() {
+				err := invalidTransferCommandExecution("instance-name", "--from", "from_platform", "--to", "to_platform", "--id", "1234")
+				Expect(err.Error()).To(Equal("errored"))
+			})
+		})
+
+		When("get instance fails", func() {
+			BeforeEach(func() {
+				client.ListInstancesReturnsOnCall(0, &types.ServiceInstances{
+					ServiceInstances: []types.ServiceInstance{
+						types.ServiceInstance{
+							Name: "instance-name",
+						},
+						types.ServiceInstance{
+							Name: "instance-name",
+						},
+					},
+				}, nil)
+
+				client.GetInstanceByIDReturns(&types.ServiceInstance{
+					Name: "instance-name",
+				}, nil)
+
+				client.UpdateInstanceReturns(nil, "", errors.New("errored"))
+			})
+
+			It("should return error", func() {
+				err := invalidTransferCommandExecution("instance-name", "--from", "from_platform", "--to", "to_platform", "--id", "1234")
+				Expect(err.Error()).To(Equal("errored"))
+			})
+		})
+	})
+
+})

--- a/internal/cmd/instance/transfer_test.go
+++ b/internal/cmd/instance/transfer_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Transfer Command test", func() {
 			Context("when no instance id is provided", func() {
 				It("should require flag for instance id", func() {
 					err := invalidTransferCommandExecution("instance-name", "--from", "from_platform", "--to", "to_platform")
-					Expect(err.Error()).To(Equal("More than 1 instance found with name instance-name. Use --id flag to specify one"))
+					Expect(err.Error()).To(Equal("more than 1 instance found with name instance-name. Use --id flag to specify one"))
 				})
 			})
 
@@ -141,7 +141,7 @@ var _ = Describe("Transfer Command test", func() {
 
 			It("should fail to transfer", func() {
 				err := invalidTransferCommandExecution("no-instance", "--from", "from_platform", "--to", "to_platform")
-				Expect(err.Error()).To(Equal("No instances found with name no-instance"))
+				Expect(err.Error()).To(Equal("no instances found with name no-instance"))
 			})
 		})
 

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 			instance.NewGetInstanceCmd(context),
 			instance.NewProvisionCmd(context),
 			instance.NewDeprovisionCmd(context, os.Stdin),
-			instance.NewTransferCmd(context),
+			instance.NewTransferCmd(context, os.Stdin),
 		},
 		PrepareFn: cmd.SmPrepare,
 	}

--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ func main() {
 			instance.NewGetInstanceCmd(context),
 			instance.NewProvisionCmd(context),
 			instance.NewDeprovisionCmd(context, os.Stdin),
+			instance.NewTransferCmd(context),
 		},
 		PrepareFn: cmd.SmPrepare,
 	}

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -62,6 +62,7 @@ type Client interface {
 
 	ListInstances(*query.Parameters) (*types.ServiceInstances, error)
 	GetInstanceByID(string, *query.Parameters) (*types.ServiceInstance, error)
+	UpdateInstance(string, *types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Provision(*types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Deprovision(string, *query.Parameters) (string, error)
 
@@ -390,6 +391,15 @@ func (client *serviceManagerClient) delete(url string, q *query.Parameters) (str
 func (client *serviceManagerClient) UpdateBroker(id string, updatedBroker *types.Broker, q *query.Parameters) (*types.Broker, string, error) {
 	var result *types.Broker
 	location, err := client.update(updatedBroker, web.ServiceBrokersURL, id, q, &result)
+	if err != nil {
+		return nil, "", err
+	}
+	return result, location, nil
+}
+
+func (client *serviceManagerClient) UpdateInstance(id string, updatedInstance *types.ServiceInstance, q *query.Parameters) (*types.ServiceInstance, string, error) {
+	var result *types.ServiceInstance
+	location, err := client.update(updatedInstance, web.ServiceInstancesURL, id, q, &result)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -372,6 +372,23 @@ type FakeClient struct {
 		result2 string
 		result3 error
 	}
+	UpdateInstanceStub        func(string, *types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
+	updateInstanceMutex       sync.RWMutex
+	updateInstanceArgsForCall []struct {
+		arg1 string
+		arg2 *types.ServiceInstance
+		arg3 *query.Parameters
+	}
+	updateInstanceReturns struct {
+		result1 *types.ServiceInstance
+		result2 string
+		result3 error
+	}
+	updateInstanceReturnsOnCall map[int]struct {
+		result1 *types.ServiceInstance
+		result2 string
+		result3 error
+	}
 	UpdatePlatformStub        func(string, *types.Platform, *query.Parameters) (*types.Platform, error)
 	updatePlatformMutex       sync.RWMutex
 	updatePlatformArgsForCall []struct {
@@ -2067,6 +2084,74 @@ func (fake *FakeClient) UpdateBrokerReturnsOnCall(i int, result1 *types.Broker, 
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) UpdateInstance(arg1 string, arg2 *types.ServiceInstance, arg3 *query.Parameters) (*types.ServiceInstance, string, error) {
+	fake.updateInstanceMutex.Lock()
+	ret, specificReturn := fake.updateInstanceReturnsOnCall[len(fake.updateInstanceArgsForCall)]
+	fake.updateInstanceArgsForCall = append(fake.updateInstanceArgsForCall, struct {
+		arg1 string
+		arg2 *types.ServiceInstance
+		arg3 *query.Parameters
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateInstance", []interface{}{arg1, arg2, arg3})
+	fake.updateInstanceMutex.Unlock()
+	if fake.UpdateInstanceStub != nil {
+		return fake.UpdateInstanceStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.updateInstanceReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) UpdateInstanceCallCount() int {
+	fake.updateInstanceMutex.RLock()
+	defer fake.updateInstanceMutex.RUnlock()
+	return len(fake.updateInstanceArgsForCall)
+}
+
+func (fake *FakeClient) UpdateInstanceCalls(stub func(string, *types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)) {
+	fake.updateInstanceMutex.Lock()
+	defer fake.updateInstanceMutex.Unlock()
+	fake.UpdateInstanceStub = stub
+}
+
+func (fake *FakeClient) UpdateInstanceArgsForCall(i int) (string, *types.ServiceInstance, *query.Parameters) {
+	fake.updateInstanceMutex.RLock()
+	defer fake.updateInstanceMutex.RUnlock()
+	argsForCall := fake.updateInstanceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) UpdateInstanceReturns(result1 *types.ServiceInstance, result2 string, result3 error) {
+	fake.updateInstanceMutex.Lock()
+	defer fake.updateInstanceMutex.Unlock()
+	fake.UpdateInstanceStub = nil
+	fake.updateInstanceReturns = struct {
+		result1 *types.ServiceInstance
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) UpdateInstanceReturnsOnCall(i int, result1 *types.ServiceInstance, result2 string, result3 error) {
+	fake.updateInstanceMutex.Lock()
+	defer fake.updateInstanceMutex.Unlock()
+	fake.UpdateInstanceStub = nil
+	if fake.updateInstanceReturnsOnCall == nil {
+		fake.updateInstanceReturnsOnCall = make(map[int]struct {
+			result1 *types.ServiceInstance
+			result2 string
+			result3 error
+		})
+	}
+	fake.updateInstanceReturnsOnCall[i] = struct {
+		result1 *types.ServiceInstance
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeClient) UpdatePlatform(arg1 string, arg2 *types.Platform, arg3 *query.Parameters) (*types.Platform, error) {
 	fake.updatePlatformMutex.Lock()
 	ret, specificReturn := fake.updatePlatformReturnsOnCall[len(fake.updatePlatformArgsForCall)]
@@ -2252,6 +2337,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.unbindMutex.RUnlock()
 	fake.updateBrokerMutex.RLock()
 	defer fake.updateBrokerMutex.RUnlock()
+	fake.updateInstanceMutex.RLock()
+	defer fake.updateInstanceMutex.RUnlock()
 	fake.updatePlatformMutex.RLock()
 	defer fake.updatePlatformMutex.RUnlock()
 	fake.updateVisibilityMutex.RLock()

--- a/pkg/smclient/test/instance_test.go
+++ b/pkg/smclient/test/instance_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Instance test", func() {
 
 		Context("When invalid config is set", func() {
 			It("should return error", func() {
-				client = smclient.NewClient(context.TODO(),fakeAuthClient, "invalidURL")
+				client = smclient.NewClient(context.TODO(), fakeAuthClient, "invalidURL")
 				_, location, err := client.Provision(instance, params)
 
 				Expect(err).Should(HaveOccurred())
@@ -429,7 +429,7 @@ var _ = Describe("Instance test", func() {
 
 		Context("When invalid config is set", func() {
 			It("should return error", func() {
-				client = smclient.NewClient(fakeAuthClient, "invalidURL")
+				client = smclient.NewClient(context.TODO(), fakeAuthClient, "invalidURL")
 				_, location, err := client.UpdateInstance(instance.ID, instance, params)
 
 				Expect(err).Should(HaveOccurred())

--- a/pkg/smclient/test/instance_test.go
+++ b/pkg/smclient/test/instance_test.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"encoding/json"
-	"github.com/Peripli/service-manager-cli/pkg/smclient"
 	"net/http"
+
+	"github.com/Peripli/service-manager-cli/pkg/smclient"
 
 	"github.com/Peripli/service-manager/pkg/web"
 
@@ -312,6 +313,126 @@ var _ = Describe("Instance test", func() {
 				Expect(err).Should(HaveOccurred())
 				Expect(location).Should(BeEmpty())
 				verifyErrorMsg(err.Error(), handlerDetails[0].Path+instance.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+			})
+		})
+	})
+
+	Describe("Update", func() {
+		Context("When valid instance is being updated synchronously", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(instance)
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.ServiceInstancesURL + "/" + instance.ID, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should update successfully", func() {
+				responseInstance, location, err := client.UpdateInstance(instance.ID, instance, params)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(location).Should(HaveLen(0))
+				Expect(responseInstance).To(Equal(instance))
+			})
+		})
+
+		Context("When valid instance is being updated asynchronously", func() {
+			var locationHeader string
+			BeforeEach(func() {
+				locationHeader = "test-location"
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.ServiceInstancesURL + "/" + instance.ID, ResponseStatusCode: http.StatusAccepted, Headers: map[string]string{"Location": locationHeader}},
+				}
+			})
+			It("should receive operation location", func() {
+				responseInstance, location, err := client.UpdateInstance(instance.ID, instance, params)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(location).Should(Equal(locationHeader))
+				Expect(responseInstance).To(BeNil())
+			})
+		})
+
+		Context("When invalid instance is being returned by SM", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(struct {
+					Name bool `json:"name"`
+				}{
+					Name: true,
+				})
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodPatch, Path: web.ServiceInstancesURL + "/" + instance.ID, ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return error", func() {
+				responseInstance, location, err := client.UpdateInstance(instance.ID, instance, params)
+
+				Expect(err).Should(HaveOccurred())
+				Expect(location).Should(BeEmpty())
+				Expect(responseInstance).To(BeNil())
+			})
+		})
+
+		Context("When invalid status code is returned by SM", func() {
+			Context("And status code is unsuccessful", func() {
+				BeforeEach(func() {
+					responseBody, _ := json.Marshal(instance)
+					handlerDetails = []HandlerDetails{
+						{Method: http.MethodPatch, Path: web.ServiceInstancesURL + "/" + instance.ID, ResponseBody: responseBody, ResponseStatusCode: http.StatusTeapot},
+					}
+				})
+				It("should return error with status code", func() {
+					responseInstance, location, err := client.UpdateInstance(instance.ID, instance, params)
+
+					Expect(err).Should(HaveOccurred())
+					Expect(location).Should(BeEmpty())
+					verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+					Expect(responseInstance).To(BeNil())
+				})
+			})
+
+			Context("And status code is unsuccessful", func() {
+				BeforeEach(func() {
+					responseBody := []byte(`{ "description": "description", "error": "error"}`)
+					handlerDetails = []HandlerDetails{
+						{Method: http.MethodPatch, Path: web.ServiceInstancesURL + "/" + instance.ID, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+					}
+				})
+				It("should return error with url and description", func() {
+					responseInstance, location, err := client.UpdateInstance(instance.ID, instance, params)
+
+					Expect(err).Should(HaveOccurred())
+					Expect(location).Should(BeEmpty())
+					verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+					Expect(responseInstance).To(BeNil())
+				})
+			})
+
+			Context("And invalid response body", func() {
+				BeforeEach(func() {
+					responseBody := []byte(`{ "description": description", "error": "error"}`)
+					handlerDetails = []HandlerDetails{
+						{Method: http.MethodPatch, Path: web.ServiceInstancesURL + "/" + instance.ID, ResponseBody: responseBody, ResponseStatusCode: http.StatusBadRequest},
+					}
+				})
+				It("should return error without url and description if invalid response body", func() {
+					responseInstance, location, err := client.UpdateInstance(instance.ID, instance, params)
+
+					Expect(err).Should(HaveOccurred())
+					Expect(location).Should(BeEmpty())
+
+					verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+					Expect(responseInstance).To(BeNil())
+				})
+			})
+
+		})
+
+		Context("When invalid config is set", func() {
+			It("should return error", func() {
+				client = smclient.NewClient(fakeAuthClient, "invalidURL")
+				_, location, err := client.UpdateInstance(instance.ID, instance, params)
+
+				Expect(err).Should(HaveOccurred())
+				Expect(location).Should(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
## Motivation

Transfer instance command is a command for easier usage of updating a service instance and transferring it to another platform

#### Pull Request status

- [x] Initial implementation
- [x] Unit tests
