### PR TITLE
[WIP] Fix update broker documentation (broker_url parameter)

### DIFF
--- a/docs/commands/update-broker.md
+++ b/docs/commands/update-broker.md
@@ -10,7 +10,7 @@ smctl update-broker [name] <json_broker> [flags]
 
 ## Example
 ```bash
-smctl update-broker broker '{"name": "new-name", "description": "new-description", "broker-url": "http://broker.com", "credentials": { "basic": { "username": "admin", "password": "admin" } }}'
+smctl update-broker broker '{"name": "new-name", "description": "new-description", "broker_url": "http://broker.com", "credentials": { "basic": { "username": "admin", "password": "admin" } }}'
 ```
 
 ## Aliases

--- a/internal/cmd/broker/update_broker.go
+++ b/internal/cmd/broker/update_broker.go
@@ -101,7 +101,7 @@ func (ubc *UpdateBrokerCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		Short:   "Updates broker",
 		Long: `Update broker with name.
 Example:
-smctl update-broker broker '{"name": "new-name", "description": "new-description", "broker-url": "http://broker.com", "credentials": { "basic": { "username": "admin", "password": "admin" } }}'`,
+smctl update-broker broker '{"name": "new-name", "description": "new-description", "broker_url": "http://broker.com", "credentials": { "basic": { "username": "admin", "password": "admin" } }}'`,
 		PreRunE: prepare(ubc, ubc.Context),
 		RunE:    cmd.RunE(ubc),
 	}


### PR DESCRIPTION
The update only works with broker_url. The parameter broker-url does not work.

# Pull Request Template

Closes #78 

## Motivation
Wrong Documentation

## Approach
Correct documentation

#### Pull Request status
- [x] Documentation Changed
- [x] Code for documentation generation changed

See also [SM API documentation](https://github.com/Peripli/specification/blob/master/api.md#request-body-2), which uses broker_url