### PR TITLE
Retrieve instance Parameters of service instances and bindings

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  branch = "parameters-instance-binding"
+  version = "0.10.0"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  version = "0.10.0"
+  version = "0.16.7"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  version = "0.10.0"
+  branch = "parameters-instance-binding"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/docs/commands/get-binding.md
+++ b/docs/commands/get-binding.md
@@ -7,7 +7,7 @@
 Get detailed information about the service binding with provided name.
 
 ## Usage
-// TODO update
+
 `smctl get-binding [name] [flags]`
 
 ## Aliases
@@ -22,6 +22,7 @@ get-binding, gsb
 | -o, --output Output format of the command. Possible opitons: json, yaml, text.| No|
 | --config Set the path for the smctl config.json file (default is $HOME/.sm/config.json).|Yes|
 | -v, --verbose Use verbose mode.|Yes|
+| --binding-params  Show service binding configuration parameters.| No |
 
 ## Example
 
@@ -37,4 +38,15 @@ One service binding.
 | Ready          | true                                                |
 | Labels         | tenant=tenant-id                                    |
 | Last Op        | create succeeded                                    |
+```
+
+
+```
+▶ smctl get-binding sample-binding --binding-params
+Showing parameters for service binding id:  0c170e73-28bd-47ea-b3f4-f1ad1dbf3e0a
+The parameters are:
+{
+   "param1":"value1",
+   "param2":"value2"
+}
 ```

--- a/docs/commands/get-binding.md
+++ b/docs/commands/get-binding.md
@@ -22,7 +22,7 @@ get-binding, gsb
 | -o, --output Output format of the command. Possible opitons: json, yaml, text.| No|
 | --config Set the path for the smctl config.json file (default is $HOME/.sm/config.json).|Yes|
 | -v, --verbose Use verbose mode.|Yes|
-| --binding-params  Show service binding configuration parameters.| No |
+| --show-binding-params  Show service binding configuration parameters.| No |
 
 ## Example
 
@@ -42,7 +42,7 @@ One service binding.
 
 
 ```
-▶ smctl get-binding sample-binding --binding-params
+▶ smctl get-binding sample-binding --show-binding-params
 Showing parameters for service binding id:  0c170e73-28bd-47ea-b3f4-f1ad1dbf3e0a
 The parameters are:
 {

--- a/docs/commands/get-binding.md
+++ b/docs/commands/get-binding.md
@@ -7,7 +7,7 @@
 Get detailed information about the service binding with provided name.
 
 ## Usage
-
+// TODO update
 `smctl get-binding [name] [flags]`
 
 ## Aliases

--- a/docs/commands/get-instance.md
+++ b/docs/commands/get-instance.md
@@ -7,7 +7,7 @@
 Get detailed information about the service instance with provided name.
 
 ## Usage
-// TODO update
+
 `smctl get-instance [name] [flags]`
 
 ## Aliases
@@ -22,6 +22,7 @@ get-instance, gi
 | -o, --output Output format of the command. Possible opitons: json, yaml, text.| No|
 | --config Set the path for the smctl config.json file (default is $HOME/.sm/config.json).|Yes|
 | -v, --verbose Use verbose mode.|Yes|
+| --instance-params  Show the service instance configuration parameters.| No |
 
 ## Example
 
@@ -38,4 +39,14 @@ One service instance.
 | Usable           | true                                  |
 | Labels           | tenant=tenant-id                      |
 | Last Op          | create succeeded                      |
+```
+
+```
+▶ smctl get-instance sample-instance --instance-params
+Showing parameters for service instance id:  0c170e73-28bd-47ea-b3f4-f1ad1dbf3e0a
+The parameters are:
+{
+   "param1":"value1",
+   "param2":"value2"
+}
 ```

--- a/docs/commands/get-instance.md
+++ b/docs/commands/get-instance.md
@@ -7,7 +7,7 @@
 Get detailed information about the service instance with provided name.
 
 ## Usage
-
+// TODO update
 `smctl get-instance [name] [flags]`
 
 ## Aliases

--- a/docs/commands/get-instance.md
+++ b/docs/commands/get-instance.md
@@ -22,7 +22,7 @@ get-instance, gi
 | -o, --output Output format of the command. Possible opitons: json, yaml, text.| No|
 | --config Set the path for the smctl config.json file (default is $HOME/.sm/config.json).|Yes|
 | -v, --verbose Use verbose mode.|Yes|
-| --instance-params  Show the service instance configuration parameters.| No |
+| --show-instance-params  Show the service instance configuration parameters.| No |
 
 ## Example
 
@@ -42,7 +42,7 @@ One service instance.
 ```
 
 ```
-▶ smctl get-instance sample-instance --instance-params
+▶ smctl get-instance sample-instance --show-instance-params
 Showing parameters for service instance id:  0c170e73-28bd-47ea-b3f4-f1ad1dbf3e0a
 The parameters are:
 {

--- a/internal/cmd/binding/get_binding.go
+++ b/internal/cmd/binding/get_binding.go
@@ -34,7 +34,7 @@ type GetBindingCmd struct {
 
 	bindingName  string
 	outputFormat output.Format
-	bindingParams bool
+	bindingParams *bool
 }
 
 // NewGetBindingCmd returns new get status command with context
@@ -56,7 +56,7 @@ func (gb *GetBindingCmd) Run() error {
 		output.PrintMessage(gb.Output, "No binding found with name: %s", gb.bindingName)
 		return nil
 	}
-	if gb.bindingParams {
+	if *gb.bindingParams {
 		return gb.printParameters(bindings)
 	}
 
@@ -146,8 +146,7 @@ func (gb *GetBindingCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-
-	result.Flags().BoolVar(&gb.bindingParams, "binding-params", false, "Get service binding params")
+	gb.bindingParams = result.PersistentFlags().Bool("binding-params",false , "Get service binding params")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/binding/get_binding.go
+++ b/internal/cmd/binding/get_binding.go
@@ -106,9 +106,11 @@ func (gb *GetBindingCmd) printParameters(bindings *types.ServiceBindings) error 
 			output.PrintMessage(gb.Output, "No parameters are set for service binding id: %s\n\n", binding.ID)
 			continue
 		}
+
+
 		output.PrintMessage(gb.Output, "Showing parameters for service binding id: %s \n", binding.ID)
 		output.PrintMessage(gb.Output, "The parameters are: \n")
-		output.PrintMessage(gb.Output, "%s \n\n ",parameters)
+		output.PrintMessage(gb.Output, "%s \n\n ",output.PrintParameters(parameters))
 	}
 
 	output.Println(gb.Output)
@@ -147,7 +149,7 @@ func (gb *GetBindingCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-	gb.bindingParams = result.PersistentFlags().Bool("binding-params",false , "Show service binding configuration parameters")
+	gb.bindingParams = result.PersistentFlags().Bool("binding-params",false , "Show the service binding configuration parameters")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/binding/get_binding.go
+++ b/internal/cmd/binding/get_binding.go
@@ -98,18 +98,18 @@ func (gb *GetBindingCmd) printParameters(bindings *types.ServiceBindings) error 
 			if strings.Contains(err.Error(), "StatusCode: 404") {
 				continue
 			}
-			output.PrintMessage(gb.Output, "Unable to show parameters for service binding id: %s\n", binding.ID)
-			output.PrintMessage(gb.Output, "The error is: %s\n\n", err)
+			output.PrintMessage(gb.Output, "Unable to show configuration parameters for service binding id: %s\n", binding.ID)
+			output.PrintMessage(gb.Output, "The error: %s\n\n", err)
 			continue
 		}
 		if len(parameters) == 0 {
-			output.PrintMessage(gb.Output, "No parameters are set for service binding id: %s\n\n", binding.ID)
+			output.PrintMessage(gb.Output, "No configuration parameters are set for service binding id: %s\n\n", binding.ID)
 			continue
 		}
 
 
-		output.PrintMessage(gb.Output, "Showing parameters for service binding id: %s \n", binding.ID)
-		output.PrintMessage(gb.Output, "The parameters are: \n")
+		output.PrintMessage(gb.Output, "Showing configuration parameters for service binding id: %s \n", binding.ID)
+		output.PrintMessage(gb.Output, "The parameters: \n")
 		output.PrintMessage(gb.Output, "%s \n\n ",output.PrintParameters(parameters))
 	}
 
@@ -149,7 +149,7 @@ func (gb *GetBindingCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-	gb.bindingParams = result.PersistentFlags().Bool("binding-params",false , "Show the service binding configuration parameters")
+	gb.bindingParams = result.PersistentFlags().Bool("show-binding-params",false , "Show the service binding configuration parameters")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/binding/get_binding.go
+++ b/internal/cmd/binding/get_binding.go
@@ -98,16 +98,17 @@ func (gb *GetBindingCmd) printParameters(bindings *types.ServiceBindings) error 
 			if strings.Contains(err.Error(), "StatusCode: 404") {
 				continue
 			}
-			output.PrintMessage(gb.Output, "Unable to show parameters for service binding id: %s", binding.ID)
-			output.PrintMessage(gb.Output, "The error is: %s", err)
+			output.PrintMessage(gb.Output, "Unable to show parameters for service binding id: %s\n", binding.ID)
+			output.PrintMessage(gb.Output, "The error is: %s\n\n", err)
 			continue
 		}
 		if len(parameters) == 0 {
-			output.PrintMessage(gb.Output, "No parameters are set for service binding id: %s", binding.ID)
+			output.PrintMessage(gb.Output, "No parameters are set for service binding id: %s\n\n", binding.ID)
 			continue
 		}
-		output.PrintMessage(gb.Output, "Showing parameters for service binding id: %s", binding.ID)
-		output.PrintMessage(gb.Output, "The parameters are: %s", parameters)
+		output.PrintMessage(gb.Output, "Showing parameters for service binding id: %s \n", binding.ID)
+		output.PrintMessage(gb.Output, "The parameters are: \n")
+		output.PrintMessage(gb.Output, "%s \n\n ",parameters)
 	}
 
 	output.Println(gb.Output)
@@ -146,7 +147,7 @@ func (gb *GetBindingCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-	gb.bindingParams = result.PersistentFlags().Bool("binding-params",false , "Get service binding params")
+	gb.bindingParams = result.PersistentFlags().Bool("binding-params",false , "Show service binding configuration parameters")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/binding/get_binding_test.go
+++ b/internal/cmd/binding/get_binding_test.go
@@ -149,15 +149,15 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when two bindings  with same name exists," +
-			"one with parameters and the second without  parameters", func() {
+		Context("when two bindings with same name exists," +
+			"one with parameters and the second without parameters", func() {
 			var response *types.ServiceBindings
 			BeforeEach(func() {
 				response = &types.ServiceBindings{ServiceBindings: []types.ServiceBinding{binding, binding2}, Vertical: true}
 				client.ListBindingsReturns(response, nil)
 			})
 
-			It("should return both bindings parameters", func() {
+			It("should return parameters both bindings", func() {
 				client.GetBindingParametersReturnsOnCall(0, bindingParameters1 , nil)
 				client.GetBindingParametersReturnsOnCall(1, bindingParameters2, nil)
 				err := executeWithArgs("binding1", "--show-binding-params")

--- a/internal/cmd/binding/get_binding_test.go
+++ b/internal/cmd/binding/get_binding_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Get binding command test", func() {
 			client.GetInstanceByIDReturnsOnCall(0, &instance1, nil)
 			client.GetInstanceByIDReturnsOnCall(1, &instance2, nil)
 		})
-		Context("when no binding name is provided", func() {
+		When("no binding name is provided", func() {
 			It("should return error", func() {
 				client.GetBindingByIDReturns(&binding, nil)
 				err := executeWithArgs("")
@@ -68,7 +68,7 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when more than one binding with same name exists", func() {
+		When("more than one binding with same name exists", func() {
 			var response *types.ServiceBindings
 			BeforeEach(func() {
 				response = &types.ServiceBindings{ServiceBindings: []types.ServiceBinding{binding, binding2}, Vertical: true}
@@ -85,7 +85,7 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when no known binding name is provided", func() {
+		When("no known binding name is provided", func() {
 			It("should return no binding", func() {
 				client.ListBindingsReturns(&types.ServiceBindings{}, nil)
 				err := executeWithArgs("unknown")
@@ -95,7 +95,7 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when binding with name is found", func() {
+		When("binding with name is found", func() {
 			It("should return its data", func() {
 				client.GetBindingByIDReturns(&binding, nil)
 				err := executeWithArgs("binding1")
@@ -111,7 +111,7 @@ var _ = Describe("Get binding command test", func() {
 		bindingParameters1 := map[string]interface{}{"param1":"value1","param2":"value2"}
 		bindingParameters2 := make(map[string]interface{})
 
-		Context("when no binding name is provided", func() {
+		When("no binding name is provided", func() {
 			It("should return error", func() {
 				err := executeWithArgs("", "--show-binding-params")
 
@@ -119,7 +119,7 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when no known binding name is provided", func() {
+		When("no known binding name is provided", func() {
 			It("should print no binding found", func() {
 				client.ListBindingsReturns(&types.ServiceBindings{}, nil)
 				err := executeWithArgs("unknown", "--show-binding-params")
@@ -129,7 +129,7 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when there is binding with this name with parameters", func() {
+		When("there is binding with this name with parameters", func() {
 			It("should print parameters", func() {
 				client.GetBindingParametersReturns(bindingParameters1, nil)
 				err := executeWithArgs("binding1", "--show-binding-params")
@@ -139,7 +139,7 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when there is instance with this name without parameters", func() {
+		When("there is instance with this name without parameters", func() {
 			It("should print no parameters", func() {
 				client.GetBindingParametersReturns(bindingParameters2, nil)
 				err := executeWithArgs("binding1", "--show-binding-params")
@@ -149,7 +149,7 @@ var _ = Describe("Get binding command test", func() {
 			})
 		})
 
-		Context("when two bindings with same name exists," +
+		When("two bindings with same name exists," +
 			"one with parameters and the second without parameters", func() {
 			var response *types.ServiceBindings
 			BeforeEach(func() {
@@ -165,7 +165,6 @@ var _ = Describe("Get binding command test", func() {
 
 				Expect(buffer.String()).To(ContainSubstring(output.PrintParameters(bindingParameters1)))
 				Expect(buffer.String()).To(ContainSubstring("No configuration parameters are set for service binding id: %s", binding2.ID))
-
 			})
 		})
 	})

--- a/internal/cmd/instance/get_instance.go
+++ b/internal/cmd/instance/get_instance.go
@@ -84,6 +84,8 @@ func (gb *GetInstanceCmd) Run() error {
 }
 
 func (gb *GetInstanceCmd) printParameters(instances *types.ServiceInstances) error {
+
+
 	for _, instance := range instances.ServiceInstances {
 		parameters, err := gb.Client.GetInstanceParameters(instance.ID, &gb.Parameters)
 		if err != nil {
@@ -91,16 +93,18 @@ func (gb *GetInstanceCmd) printParameters(instances *types.ServiceInstances) err
 			if strings.Contains(err.Error(), "StatusCode: 404") {
 				continue
 			}
-			output.PrintMessage(gb.Output, "Unable to show parameters for service instance id: %s", instance.ID)
-			output.PrintMessage(gb.Output, "The error is: %s", err)
+			output.PrintMessage(gb.Output, "Unable to show parameters for service instance id: %s\n", instance.ID)
+			output.PrintMessage(gb.Output, "The error is: %s\n\n", err)
 			continue
 		}
 		if len(parameters) == 0 {
-			output.PrintMessage(gb.Output, "No parameters are set for service instance id: %s", instance.ID)
+			output.PrintMessage(gb.Output, "No parameters are set for service instance id: %s\n\n", instance.ID)
 			continue
 		}
-		output.PrintMessage(gb.Output, "Showing parameters for service instance id: %s", instance.ID)
-		output.PrintMessage(gb.Output, "The parameters are: %s", parameters)
+		output.PrintMessage(gb.Output, "Showing parameters for service instance id: %s \n", instance.ID )
+		output.PrintMessage(gb.Output, "The parameters are: \n"  )
+
+		output.PrintMessage(gb.Output, "%s \n\n", parameters)
 	}
 
 	output.Println(gb.Output)
@@ -138,7 +142,7 @@ func (gb *GetInstanceCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-	gb.instanceParams = result.PersistentFlags().Bool("instance-params", false, "Get service instance params")
+	gb.instanceParams = result.PersistentFlags().Bool("instance-params", false, "Show the service instance configuration parameters")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/instance/get_instance.go
+++ b/internal/cmd/instance/get_instance.go
@@ -104,7 +104,7 @@ func (gb *GetInstanceCmd) printParameters(instances *types.ServiceInstances) err
 		output.PrintMessage(gb.Output, "Showing parameters for service instance id: %s \n", instance.ID )
 		output.PrintMessage(gb.Output, "The parameters are: \n"  )
 
-		output.PrintMessage(gb.Output, "%s \n\n", parameters)
+		output.PrintMessage(gb.Output, "%s \n\n", output.PrintParameters(parameters))
 	}
 
 	output.Println(gb.Output)

--- a/internal/cmd/instance/get_instance.go
+++ b/internal/cmd/instance/get_instance.go
@@ -33,8 +33,8 @@ type GetInstanceCmd struct {
 	*cmd.Context
 
 	instanceName string
-	instanceParams bool
 	outputFormat output.Format
+	instanceParams *bool
 }
 
 // NewGetInstanceCmd returns new get status command with context
@@ -56,7 +56,7 @@ func (gb *GetInstanceCmd) Run() error {
 		output.PrintMessage(gb.Output, "No instance found with name: %s", gb.instanceName)
 		return nil
 	}
-	if gb.instanceParams {
+	if *gb.instanceParams {
 		return gb.printParameters(instances)
 	}
 
@@ -138,8 +138,7 @@ func (gb *GetInstanceCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-
-	result.Flags().BoolVar(&gb.instanceParams, "instance-params", false, "Get service instance params")
+	gb.instanceParams = result.PersistentFlags().Bool("instance-params", false, "Get service instance params")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/instance/get_instance.go
+++ b/internal/cmd/instance/get_instance.go
@@ -93,16 +93,16 @@ func (gb *GetInstanceCmd) printParameters(instances *types.ServiceInstances) err
 			if strings.Contains(err.Error(), "StatusCode: 404") {
 				continue
 			}
-			output.PrintMessage(gb.Output, "Unable to show parameters for service instance id: %s\n", instance.ID)
-			output.PrintMessage(gb.Output, "The error is: %s\n\n", err)
+			output.PrintMessage(gb.Output, "Unable to show configuration parameters for service instance id: %s\n", instance.ID)
+			output.PrintMessage(gb.Output, "The error: %s\n\n", err)
 			continue
 		}
 		if len(parameters) == 0 {
-			output.PrintMessage(gb.Output, "No parameters are set for service instance id: %s\n\n", instance.ID)
+			output.PrintMessage(gb.Output, "No configuration parameters are set for service instance id: %s\n\n", instance.ID)
 			continue
 		}
-		output.PrintMessage(gb.Output, "Showing parameters for service instance id: %s \n", instance.ID )
-		output.PrintMessage(gb.Output, "The parameters are: \n"  )
+		output.PrintMessage(gb.Output, "Showing configuration parameters for service instance id: %s \n", instance.ID )
+		output.PrintMessage(gb.Output, "The parameters: \n"  )
 
 		output.PrintMessage(gb.Output, "%s \n\n", output.PrintParameters(parameters))
 	}
@@ -142,7 +142,7 @@ func (gb *GetInstanceCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-	gb.instanceParams = result.PersistentFlags().Bool("instance-params", false, "Show the service instance configuration parameters")
+	gb.instanceParams = result.PersistentFlags().Bool("show-instance-params", false, "Show the service instance configuration parameters")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/instance/get_instance_test.go
+++ b/internal/cmd/instance/get_instance_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Get instance command test", func() {
 
 	Describe("Get service instance", func() {
 
-		Context("when no instance name is provided", func() {
+		When("no instance name is provided", func() {
 			It("should return error", func() {
 				client.GetInstanceByIDReturns(&instance, nil)
 				err := executeWithArgs("")
@@ -52,7 +52,7 @@ var _ = Describe("Get instance command test", func() {
 			})
 		})
 
-		Context("when more than one instance with same name exists", func() {
+		When("more than one instance with same name exists", func() {
 			var response *types.ServiceInstances
 			BeforeEach(func() {
 				response = &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance, instance2}, Vertical: true}
@@ -69,7 +69,7 @@ var _ = Describe("Get instance command test", func() {
 			})
 		})
 
-		Context("when no known instance name is provided", func() {
+		When("no known instance name is provided", func() {
 			It("should return no instance", func() {
 				client.ListInstancesReturns(&types.ServiceInstances{}, nil)
 				err := executeWithArgs("unknown")
@@ -79,7 +79,7 @@ var _ = Describe("Get instance command test", func() {
 			})
 		})
 
-		Context("when instance with name is found", func() {
+		When("instance with name is found", func() {
 			It("should return its data", func() {
 				client.GetInstanceByIDReturns(&instance, nil)
 				err := executeWithArgs("instance1")
@@ -95,7 +95,7 @@ var _ = Describe("Get instance command test", func() {
 		instanceParameters1 := map[string]interface{}{"param1":"value1","param2":"value2"}
 		instanceParameters2 := make(map[string]interface{})
 
-		Context("when no instance name is provided", func() {
+		When("no instance name is provided", func() {
 			It("should return error", func() {
 				err := executeWithArgs("", "--show-instance-params")
 
@@ -103,7 +103,7 @@ var _ = Describe("Get instance command test", func() {
 			})
 		})
 
-		Context("when no known instance name is provided", func() {
+		When("no known instance name is provided", func() {
 			It("should print no instance found", func() {
 				client.ListInstancesReturns(&types.ServiceInstances{}, nil)
 				err := executeWithArgs("unknown", "--show-instance-params")
@@ -113,7 +113,7 @@ var _ = Describe("Get instance command test", func() {
 			})
 		})
 
-		Context("when there is instance with this name with parameters", func() {
+		When("there is instance with this name with parameters", func() {
 			It("should print parameters", func() {
 				client.GetInstanceParametersReturns(instanceParameters1, nil)
 				err := executeWithArgs("instance1", "--show-instance-params")
@@ -123,7 +123,7 @@ var _ = Describe("Get instance command test", func() {
 			})
 		})
 
-		Context("when there is instance with this name without parameters", func() {
+		When("there is instance with this name without parameters", func() {
 			It("should print no parameters", func() {
 				client.GetInstanceParametersReturns(instanceParameters2, nil)
 				err := executeWithArgs("instance1", "--show-instance-params")
@@ -133,7 +133,7 @@ var _ = Describe("Get instance command test", func() {
 			})
 		})
 
-		Context("when two instances with same name exists," +
+		When("two instances with same name exists," +
 			"one with parameters and the second without parameters", func() {
 			var response *types.ServiceInstances
 			BeforeEach(func() {

--- a/internal/cmd/instance/get_instance_test.go
+++ b/internal/cmd/instance/get_instance_test.go
@@ -1,10 +1,10 @@
 package instance
 
 import (
+	"bytes"
+	"github.com/Peripli/service-manager-cli/internal/output"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"bytes"
 
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
@@ -40,51 +40,116 @@ var _ = Describe("Get instance command test", func() {
 
 		return commandToRun.Execute()
 	}
+	Describe("Get service instance", func() {
 
-	Context("when no instance name is provided", func() {
-		It("should return error", func() {
-			client.GetInstanceByIDReturns(&instance, nil)
-			err := executeWithArgs("")
+		Context("when no instance name is provided", func() {
+			It("should return error", func() {
+				client.GetInstanceByIDReturns(&instance, nil)
+				err := executeWithArgs("")
 
-			Expect(err).Should(HaveOccurred())
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
+		Context("when more than one instance with same name exists", func() {
+			var response *types.ServiceInstances
+			BeforeEach(func() {
+				response = &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance, instance2}, Vertical: true}
+				client.ListInstancesReturns(response, nil)
+			})
+
+			It("should return both instances", func() {
+				client.GetInstanceByIDReturnsOnCall(0, &instance, nil)
+				client.GetInstanceByIDReturnsOnCall(1, &instance2, nil)
+				err := executeWithArgs("instance1")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(buffer.String()).To(ContainSubstring(response.TableData().String()))
+			})
+		})
+
+		Context("when no known instance name is provided", func() {
+			It("should return no instance", func() {
+				client.ListInstancesReturns(&types.ServiceInstances{}, nil)
+				err := executeWithArgs("unknown")
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring("No instance found with name: unknown"))
+			})
+		})
+
+		Context("when instance with name is found", func() {
+			It("should return its data", func() {
+				client.GetInstanceByIDReturns(&instance, nil)
+				err := executeWithArgs("instance1")
+
+				Expect(err).ShouldNot(HaveOccurred())
+				result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance}, Vertical: true}
+				Expect(buffer.String()).To(ContainSubstring(result.TableData().String()))
+			})
 		})
 	})
 
-	Context("when more than one instance with same name exists", func() {
-		var response *types.ServiceInstances
-		BeforeEach(func() {
-			response = &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance, instance2}, Vertical: true}
-			client.ListInstancesReturns(response, nil)
+	Describe("Get service instance parameters", func() {
+		instanceParameters1 := map[string]interface{}{"param1":"value1","param2":"value2"}
+		instanceParameters2 := make(map[string]interface{})
+
+		Context("when no instance name is provided", func() {
+			It("should return error", func() {
+				err := executeWithArgs("", "--show-instance-params")
+
+				Expect(err).Should(HaveOccurred())
+			})
 		})
 
-		It("should return both instances", func() {
-			client.GetInstanceByIDReturnsOnCall(0, &instance, nil)
-			client.GetInstanceByIDReturnsOnCall(1, &instance2, nil)
-			err := executeWithArgs("instance1")
-			Expect(err).ShouldNot(HaveOccurred())
+		Context("when no known instance name is provided", func() {
+			It("should print no instance found", func() {
+				client.ListInstancesReturns(&types.ServiceInstances{}, nil)
+				err := executeWithArgs("unknown", "--show-instance-params")
 
-			Expect(buffer.String()).To(ContainSubstring(response.TableData().String()))
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring("No instance found with name: unknown"))
+			})
 		})
-	})
 
-	Context("when no known instance name is provided", func() {
-		It("should return no instance", func() {
-			client.ListInstancesReturns(&types.ServiceInstances{}, nil)
-			err := executeWithArgs("unknown")
+		Context("when there is instance with this name with parameters", func() {
+			It("should print parameters", func() {
+				client.GetInstanceParametersReturns(instanceParameters1, nil)
+				err := executeWithArgs("instance1", "--show-instance-params")
 
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("No instance found with name: unknown"))
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring(output.PrintParameters(instanceParameters1)))
+			})
 		})
-	})
 
-	Context("when instance with name is found", func() {
-		It("should return its data", func() {
-			client.GetInstanceByIDReturns(&instance, nil)
-			err := executeWithArgs("instance1")
+		Context("when there is instance with this name without parameters", func() {
+			It("should print no parameters", func() {
+				client.GetInstanceParametersReturns(instanceParameters2, nil)
+				err := executeWithArgs("instance1", "--show-instance-params")
 
-			Expect(err).ShouldNot(HaveOccurred())
-			result := &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance}, Vertical: true}
-			Expect(buffer.String()).To(ContainSubstring(result.TableData().String()))
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(buffer.String()).To(ContainSubstring("No configuration parameters are set for service instance id: %s", instance.ID))
+			})
+		})
+
+		Context("when two instances with same name exists," +
+			"one with parameters and the second without  parameters", func() {
+			var response *types.ServiceInstances
+			BeforeEach(func() {
+				response = &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance, instance2}, Vertical: true}
+				client.ListInstancesReturns(response, nil)
+			})
+
+			It("should return both instances parameters", func() {
+				client.GetInstanceParametersReturnsOnCall(0, instanceParameters1, nil)
+				client.GetInstanceParametersReturnsOnCall(1, instanceParameters2, nil)
+				err := executeWithArgs("instance1", "--show-instance-params")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(buffer.String()).To(ContainSubstring(output.PrintParameters(instanceParameters1)))
+				Expect(buffer.String()).To(ContainSubstring("No configuration parameters are set for service instance id: %s", instance2.ID))
+
+			})
 		})
 	})
 })

--- a/internal/cmd/instance/get_instance_test.go
+++ b/internal/cmd/instance/get_instance_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Get instance command test", func() {
 
 		return commandToRun.Execute()
 	}
+
 	Describe("Get service instance", func() {
 
 		Context("when no instance name is provided", func() {
@@ -133,14 +134,13 @@ var _ = Describe("Get instance command test", func() {
 		})
 
 		Context("when two instances with same name exists," +
-			"one with parameters and the second without  parameters", func() {
+			"one with parameters and the second without parameters", func() {
 			var response *types.ServiceInstances
 			BeforeEach(func() {
 				response = &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance, instance2}, Vertical: true}
 				client.ListInstancesReturns(response, nil)
 			})
-
-			It("should return both instances parameters", func() {
+			It("should return parameters for both instances", func() {
 				client.GetInstanceParametersReturnsOnCall(0, instanceParameters1, nil)
 				client.GetInstanceParametersReturnsOnCall(1, instanceParameters2, nil)
 				err := executeWithArgs("instance1", "--show-instance-params")

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -19,6 +19,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"encoding/json"
 
 	"github.com/Peripli/service-manager-cli/pkg/types"
 )
@@ -102,4 +103,10 @@ func PrintFormat(wr io.Writer, outputFormat Format, encodedObject []byte, conver
 	}
 	printer.Print(wr, object)
 	return nil
+}
+
+func PrintParameters(parameters map[string]interface{}) string{
+	jsonParameters,_ := json.MarshalIndent(parameters, "", "   ")
+	stringParams := string(jsonParameters)
+	return stringParams
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -104,7 +104,7 @@ func PrintFormat(wr io.Writer, outputFormat Format, encodedObject []byte, conver
 	printer.Print(wr, object)
 	return nil
 }
-
+// PrintParameters convert map to string
 func PrintParameters(parameters map[string]interface{}) string{
 	jsonParameters,_ := json.MarshalIndent(parameters, "", "   ")
 	stringParams := string(jsonParameters)

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -63,12 +63,14 @@ type Client interface {
 
 	ListInstances(*query.Parameters) (*types.ServiceInstances, error)
 	GetInstanceByID(string, *query.Parameters) (*types.ServiceInstance, error)
+	GetInstanceParameters(string, *query.Parameters) (map[string]string, error)
 	UpdateInstance(string, *types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Provision(*types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Deprovision(string, *query.Parameters) (string, error)
 
 	ListBindings(*query.Parameters) (*types.ServiceBindings, error)
 	GetBindingByID(string, *query.Parameters) (*types.ServiceBinding, error)
+	GetBindingParameters(string, *query.Parameters) (map[string]string, error)
 	Bind(*types.ServiceBinding, *query.Parameters) (*types.ServiceBinding, string, error)
 	Unbind(string, *query.Parameters) (string, error)
 
@@ -276,6 +278,23 @@ func (client *serviceManagerClient) ListInstances(q *query.Parameters) (*types.S
 
 	return instances, err
 }
+const (
+	ParametersURL="/parameters"
+)
+func (client *serviceManagerClient) GetInstanceParameters(id string, q *query.Parameters) (map[string]string, error) {
+	parameters := make(map[string]string)
+	err := client.list(&parameters, web.ServiceInstancesURL+"/"+id+ParametersURL, q)
+
+	return parameters, err
+}
+
+func (client *serviceManagerClient) GetBindingParameters(id string, q *query.Parameters) (map[string]string, error) {
+	parameters := make(map[string]string)
+	err := client.get(parameters, web.ServiceBindingsURL+"/"+id+"/"+ParametersURL, q)
+
+	return parameters, err
+}
+
 
 // GetInstanceByID returns instance registered in the Service Manager satisfying provided queries
 func (client *serviceManagerClient) GetInstanceByID(id string, q *query.Parameters) (*types.ServiceInstance, error) {

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -512,9 +512,3 @@ func BuildURL(baseURL string, q *query.Parameters) string {
 	}
 	return baseURL + "?" + queryParams
 }
-
-func PrintFormatedParameters(parameters map[string]interface{}) string{
-	jsonParameters,_ := json.MarshalIndent(parameters, "", "   ")
-	stringParams := string(jsonParameters)
-	return stringParams
-}

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -63,14 +63,14 @@ type Client interface {
 
 	ListInstances(*query.Parameters) (*types.ServiceInstances, error)
 	GetInstanceByID(string, *query.Parameters) (*types.ServiceInstance, error)
-	GetInstanceParameters(string, *query.Parameters) (map[string]string, error)
+	GetInstanceParameters(string, *query.Parameters) (map[string]interface{}, error)
 	UpdateInstance(string, *types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Provision(*types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Deprovision(string, *query.Parameters) (string, error)
 
 	ListBindings(*query.Parameters) (*types.ServiceBindings, error)
 	GetBindingByID(string, *query.Parameters) (*types.ServiceBinding, error)
-	GetBindingParameters(string, *query.Parameters) (map[string]string, error)
+	GetBindingParameters(string, *query.Parameters) (map[string]interface{}, error)
 	Bind(*types.ServiceBinding, *query.Parameters) (*types.ServiceBinding, string, error)
 	Unbind(string, *query.Parameters) (string, error)
 
@@ -278,19 +278,17 @@ func (client *serviceManagerClient) ListInstances(q *query.Parameters) (*types.S
 
 	return instances, err
 }
-const (
-	parametersURL="/parameters"
-)
-func (client *serviceManagerClient) GetInstanceParameters(id string, q *query.Parameters) (map[string]string, error) {
-	parameters := make(map[string]string)
-	err := client.list(&parameters, web.ServiceInstancesURL+"/"+id+parametersURL, q)
+
+func (client *serviceManagerClient) GetInstanceParameters(id string, q *query.Parameters) (map[string]interface{}, error) {
+	parameters := make(map[string]interface{})
+	err := client.get(parameters, web.ServiceInstancesURL+"/"+ id + web.ParametersURL, q)
 
 	return parameters, err
 }
 
-func (client *serviceManagerClient) GetBindingParameters(id string, q *query.Parameters) (map[string]string, error) {
-	parameters := make(map[string]string)
-	err := client.get(parameters, web.ServiceBindingsURL+"/"+id+"/"+parametersURL, q)
+func (client *serviceManagerClient) GetBindingParameters(id string, q *query.Parameters) (map[string]interface{}, error) {
+	parameters := make(map[string]interface{})
+	err := client.get(parameters, web.ServiceBindingsURL+"/"+id + web.ParametersURL, q)
 
 	return parameters, err
 }

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -63,14 +63,14 @@ type Client interface {
 
 	ListInstances(*query.Parameters) (*types.ServiceInstances, error)
 	GetInstanceByID(string, *query.Parameters) (*types.ServiceInstance, error)
-	GetInstanceParameters(string, *query.Parameters) (string, error)
+	GetInstanceParameters(string, *query.Parameters) (map[string]interface{}, error)
 	UpdateInstance(string, *types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Provision(*types.ServiceInstance, *query.Parameters) (*types.ServiceInstance, string, error)
 	Deprovision(string, *query.Parameters) (string, error)
 
 	ListBindings(*query.Parameters) (*types.ServiceBindings, error)
 	GetBindingByID(string, *query.Parameters) (*types.ServiceBinding, error)
-	GetBindingParameters(string, *query.Parameters) (string, error)
+	GetBindingParameters(string, *query.Parameters) (map[string]interface{}, error)
 	Bind(*types.ServiceBinding, *query.Parameters) (*types.ServiceBinding, string, error)
 	Unbind(string, *query.Parameters) (string, error)
 
@@ -279,18 +279,11 @@ func (client *serviceManagerClient) ListInstances(q *query.Parameters) (*types.S
 	return instances, err
 }
 // GetInstanceParameters returns service instance configuration parameters
-func (client *serviceManagerClient) GetInstanceParameters(id string, q *query.Parameters) (string, error) {
+func (client *serviceManagerClient) GetInstanceParameters(id string, q *query.Parameters) (map[string]interface{}, error) {
 	parameters := make(map[string]interface{})
-	err := client.get(&parameters, web.ServiceInstancesURL+"/"+ id + web.ParametersURL, q)
+	err := client.get(&parameters, web.ServiceInstancesURL + "/" + id + web.ParametersURL, q)
 
-	if err!=nil || len(parameters)==0 {
-		return "", err
-	}
-
-	jsonParameters,_ := json.MarshalIndent(parameters, "", "   ")
-	stringParams := string(jsonParameters)
-
-	return stringParams, err
+	return parameters, err
 }
 
 // GetInstanceByID returns instance registered in the Service Manager satisfying provided queries
@@ -310,19 +303,13 @@ func (client *serviceManagerClient) ListBindings(q *query.Parameters) (*types.Se
 
 	return bindings, err
 }
+
 // GetBindingParameters returns service binding configuration parameters
-func (client *serviceManagerClient) GetBindingParameters(id string, q *query.Parameters) (string, error) {
+func (client *serviceManagerClient) GetBindingParameters(id string, q *query.Parameters) (map[string]interface{}, error) {
 	parameters := make(map[string]interface{})
-	err := client.get(&parameters, web.ServiceBindingsURL+"/"+id + web.ParametersURL, q)
+	err := client.get(&parameters, web.ServiceBindingsURL + "/" + id + web.ParametersURL, q)
 
-	if err!=nil || len(parameters)==0 {
-		return "", err
-	}
-
-	jsonParameters, _ := json.MarshalIndent(parameters, "", "   ")
-	stringParams := string(jsonParameters)
-
-	return stringParams, err
+	return parameters, err
 }
 
 // GetBindingByID returns binding registered in the Service Manager satisfying provided queries
@@ -382,29 +369,6 @@ func (client *serviceManagerClient) get(result interface{}, url string, q *query
 
 	return httputil.UnmarshalResponse(resp, &result)
 }
-
-//func (client *serviceManagerClient) getParams(result interface{}, url string, q *query.Parameters) error {
-//
-//
-//
-//	resp, err := client.Call(http.MethodGet, url, nil, q)
-//	if err != nil {
-//		return err
-//	}
-//
-//	defer func() {
-//		err := resp.Body.Close()
-//		if err != nil {
-//			panic(err)
-//		}
-//	}()
-//
-//	if resp.StatusCode != http.StatusOK {
-//		return util.HandleResponseError(resp)
-//	}
-//
-//	return json.Unmarshal([]byte(resp.Body), &result)
-//}
 
 func (client *serviceManagerClient) DeleteBroker(id string, q *query.Parameters) (string, error) {
 	return client.delete(web.ServiceBrokersURL+"/"+id, q)
@@ -547,4 +511,10 @@ func BuildURL(baseURL string, q *query.Parameters) string {
 		return baseURL
 	}
 	return baseURL + "?" + queryParams
+}
+
+func PrintFormatedParameters(parameters map[string]interface{}) string{
+	jsonParameters,_ := json.MarshalIndent(parameters, "", "   ")
+	stringParams := string(jsonParameters)
+	return stringParams
 }

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -279,18 +279,18 @@ func (client *serviceManagerClient) ListInstances(q *query.Parameters) (*types.S
 	return instances, err
 }
 const (
-	ParametersURL="/parameters"
+	parametersURL="/parameters"
 )
 func (client *serviceManagerClient) GetInstanceParameters(id string, q *query.Parameters) (map[string]string, error) {
 	parameters := make(map[string]string)
-	err := client.list(&parameters, web.ServiceInstancesURL+"/"+id+ParametersURL, q)
+	err := client.list(&parameters, web.ServiceInstancesURL+"/"+id+parametersURL, q)
 
 	return parameters, err
 }
 
 func (client *serviceManagerClient) GetBindingParameters(id string, q *query.Parameters) (map[string]string, error) {
 	parameters := make(map[string]string)
-	err := client.get(parameters, web.ServiceBindingsURL+"/"+id+"/"+ParametersURL, q)
+	err := client.get(parameters, web.ServiceBindingsURL+"/"+id+"/"+parametersURL, q)
 
 	return parameters, err
 }

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -108,7 +108,6 @@ type FakeClient struct {
 		result1 *types.ServiceBinding
 		result2 error
 	}
-
 	GetBindingParametersStub        func(string, *query.Parameters) (map[string]interface{}, error)
 	getBindingParametersMutex       sync.RWMutex
 	getBindingParametersArgsForCall []struct {
@@ -123,7 +122,6 @@ type FakeClient struct {
 		result1 map[string]interface{}
 		result2 error
 	}
-
 	GetBrokerByIDStub        func(string, *query.Parameters) (*types.Broker, error)
 	getBrokerByIDMutex       sync.RWMutex
 	getBrokerByIDArgsForCall []struct {
@@ -165,7 +163,6 @@ type FakeClient struct {
 		result1 *types.ServiceInstance
 		result2 error
 	}
-
 	GetInstanceParametersStub        func(string, *query.Parameters) (map[string]interface{}, error)
 	getInstanceParametersMutex       sync.RWMutex
 	getInstanceParametersArgsForCall []struct {
@@ -180,7 +177,6 @@ type FakeClient struct {
 		result1 map[string]interface{}
 		result2 error
 	}
-
 	LabelStub        func(string, string, *types.LabelChanges, *query.Parameters) error
 	labelMutex       sync.RWMutex
 	labelArgsForCall []struct {

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -166,7 +166,6 @@ type FakeClient struct {
 		result2 error
 	}
 
-
 	GetInstanceParametersStub        func(string, *query.Parameters) (map[string]interface{}, error)
 	getInstanceParametersMutex       sync.RWMutex
 	getInstanceParametersArgsForCall []struct {

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -1014,6 +1014,8 @@ func (fake *FakeClient) GetInstanceByID(arg1 string, arg2 *query.Parameters) (*t
 	return fakeReturns.result1, fakeReturns.result2
 }
 
+//HERE
+
 func (fake *FakeClient) GetInstanceByIDCallCount() int {
 	fake.getInstanceByIDMutex.RLock()
 	defer fake.getInstanceByIDMutex.RUnlock()

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -108,6 +108,22 @@ type FakeClient struct {
 		result1 *types.ServiceBinding
 		result2 error
 	}
+
+	GetBindingParametersStub        func(string, *query.Parameters) (map[string]interface{}, error)
+	getBindingParametersMutex       sync.RWMutex
+	getBindingParametersArgsForCall []struct {
+		arg1 string
+		arg2 *query.Parameters
+	}
+	getBindingParametersReturns struct {
+		result1 map[string]interface{}
+		result2 error
+	}
+	getBindingParametersReturnsOnCall map[int]struct {
+		result1 map[string]interface{}
+		result2 error
+	}
+
 	GetBrokerByIDStub        func(string, *query.Parameters) (*types.Broker, error)
 	getBrokerByIDMutex       sync.RWMutex
 	getBrokerByIDArgsForCall []struct {
@@ -149,6 +165,23 @@ type FakeClient struct {
 		result1 *types.ServiceInstance
 		result2 error
 	}
+
+
+	GetInstanceParametersStub        func(string, *query.Parameters) (map[string]interface{}, error)
+	getInstanceParametersMutex       sync.RWMutex
+	getInstanceParametersArgsForCall []struct {
+		arg1 string
+		arg2 *query.Parameters
+	}
+	getInstanceParametersReturns struct {
+		result1 map[string]interface{}
+		result2 error
+	}
+	getInstanceParametersReturnsOnCall map[int]struct {
+		result1 map[string]interface{}
+		result2 error
+	}
+
 	LabelStub        func(string, string, *types.LabelChanges, *query.Parameters) error
 	labelMutex       sync.RWMutex
 	labelArgsForCall []struct {
@@ -868,6 +901,70 @@ func (fake *FakeClient) GetBindingByIDReturnsOnCall(i int, result1 *types.Servic
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GetBindingParameters(arg1 string, arg2 *query.Parameters) (map[string]interface{}, error) {
+	fake.getBindingParametersMutex.Lock()
+	ret, specificReturn := fake.getBindingParametersReturnsOnCall[len(fake.getBindingParametersArgsForCall)]
+	fake.getBindingParametersArgsForCall = append(fake.getBindingParametersArgsForCall, struct {
+		arg1 string
+		arg2 *query.Parameters
+	}{arg1, arg2})
+	fake.recordInvocation("GetBindingParameters", []interface{}{arg1, arg2})
+	fake.getBindingParametersMutex.Unlock()
+	if fake.GetBindingParametersStub != nil {
+		return fake.GetBindingParametersStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getBindingParametersReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetBindingParametersCallCount() int {
+	fake.getBindingParametersMutex.RLock()
+	defer fake.getBindingParametersMutex.RUnlock()
+	return len(fake.getBindingParametersArgsForCall)
+}
+
+func (fake *FakeClient) GetBindingParametersCalls(stub func(string, *query.Parameters) (map[string]interface{}, error)) {
+	fake.getBindingParametersMutex.Lock()
+	defer fake.getBindingParametersMutex.Unlock()
+	fake.GetBindingParametersStub = stub
+}
+
+func (fake *FakeClient) GetBindingParametersArgsForCall(i int) (string, *query.Parameters) {
+	fake.getBindingParametersMutex.RLock()
+	defer fake.getBindingParametersMutex.RUnlock()
+	argsForCall := fake.getBindingParametersArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) GetBindingParametersReturns(result1 map[string]interface{}, result2 error) {
+	fake.getBindingParametersMutex.Lock()
+	defer fake.getBindingParametersMutex.Unlock()
+	fake.GetBindingParametersStub = nil
+	fake.getBindingParametersReturns = struct {
+		result1 map[string]interface{}
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetBindingParametersReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
+	fake.getBindingParametersMutex.Lock()
+	defer fake.getBindingParametersMutex.Unlock()
+	fake.GetBindingParametersStub = nil
+	if fake.getBindingParametersReturnsOnCall == nil {
+		fake.getBindingParametersReturnsOnCall = make(map[int]struct {
+			result1 map[string]interface{}
+			result2 error
+		})
+	}
+	fake.getBindingParametersReturnsOnCall[i] = struct {
+		result1 map[string]interface{}
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) GetBrokerByID(arg1 string, arg2 *query.Parameters) (*types.Broker, error) {
 	fake.getBrokerByIDMutex.Lock()
 	ret, specificReturn := fake.getBrokerByIDReturnsOnCall[len(fake.getBrokerByIDArgsForCall)]
@@ -1014,8 +1111,6 @@ func (fake *FakeClient) GetInstanceByID(arg1 string, arg2 *query.Parameters) (*t
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-//HERE
-
 func (fake *FakeClient) GetInstanceByIDCallCount() int {
 	fake.getInstanceByIDMutex.RLock()
 	defer fake.getInstanceByIDMutex.RUnlock()
@@ -1057,6 +1152,70 @@ func (fake *FakeClient) GetInstanceByIDReturnsOnCall(i int, result1 *types.Servi
 	}
 	fake.getInstanceByIDReturnsOnCall[i] = struct {
 		result1 *types.ServiceInstance
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetInstanceParameters(arg1 string, arg2 *query.Parameters) (map[string]interface{}, error) {
+	fake.getInstanceParametersMutex.Lock()
+	ret, specificReturn := fake.getInstanceParametersReturnsOnCall[len(fake.getInstanceParametersArgsForCall)]
+	fake.getInstanceParametersArgsForCall = append(fake.getInstanceParametersArgsForCall, struct {
+		arg1 string
+		arg2 *query.Parameters
+	}{arg1, arg2})
+	fake.recordInvocation("GetInstanceParameters", []interface{}{arg1, arg2})
+	fake.getInstanceParametersMutex.Unlock()
+	if fake.GetInstanceParametersStub != nil {
+		return fake.GetInstanceParametersStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getInstanceParametersReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetInstanceParametersCallCount() int {
+	fake.getInstanceParametersMutex.RLock()
+	defer fake.getInstanceParametersMutex.RUnlock()
+	return len(fake.getInstanceParametersArgsForCall)
+}
+
+func (fake *FakeClient) GetInstanceParametersCalls(stub func(string, *query.Parameters) (map[string]interface{}, error)) {
+	fake.getInstanceParametersMutex.Lock()
+	defer fake.getInstanceParametersMutex.Unlock()
+	fake.GetInstanceParametersStub = stub
+}
+
+func (fake *FakeClient) GetInstanceParametersArgsForCall(i int) (string, *query.Parameters) {
+	fake.getInstanceParametersMutex.RLock()
+	defer fake.getInstanceParametersMutex.RUnlock()
+	argsForCall := fake.getInstanceParametersArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) GetInstanceParametersReturns(result1 map[string]interface{}, result2 error) {
+	fake.getInstanceParametersMutex.Lock()
+	defer fake.getInstanceParametersMutex.Unlock()
+	fake.GetInstanceParametersStub = nil
+	fake.getInstanceParametersReturns = struct {
+		result1 map[string]interface{}
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetInstanceParametersReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
+	fake.getInstanceParametersMutex.Lock()
+	defer fake.getInstanceParametersMutex.Unlock()
+	fake.GetInstanceParametersStub = nil
+	if fake.getInstanceParametersReturnsOnCall == nil {
+		fake.getInstanceParametersReturnsOnCall = make(map[int]struct {
+			result1 map[string]interface{}
+			result2 error
+		})
+	}
+	fake.getInstanceParametersReturnsOnCall[i] = struct {
+		result1 map[string]interface{}
 		result2 error
 	}{result1, result2}
 }
@@ -2301,12 +2460,16 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.deprovisionMutex.RUnlock()
 	fake.getBindingByIDMutex.RLock()
 	defer fake.getBindingByIDMutex.RUnlock()
+	fake.getBindingParametersMutex.RLock()
+	defer fake.getBindingParametersMutex.RUnlock()
 	fake.getBrokerByIDMutex.RLock()
 	defer fake.getBrokerByIDMutex.RUnlock()
 	fake.getInfoMutex.RLock()
 	defer fake.getInfoMutex.RUnlock()
 	fake.getInstanceByIDMutex.RLock()
 	defer fake.getInstanceByIDMutex.RUnlock()
+	fake.getInstanceParametersMutex.RLock()
+	defer fake.getInstanceParametersMutex.RUnlock()
 	fake.labelMutex.RLock()
 	defer fake.labelMutex.RUnlock()
 	fake.listBindingsMutex.RLock()

--- a/pkg/smclient/test/binding_test.go
+++ b/pkg/smclient/test/binding_test.go
@@ -133,6 +133,87 @@ var _ = Describe("Binding test", func() {
 		})
 	})
 
+	Describe("Get service binding parameters", func() {
+		Context("when there is binding with this id with parameters", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(bindingParameters)
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return parameters", func() {
+				result, err := client.GetBindingParameters(binding.ID, params)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result).To(Equal(bindingParameters))
+			})
+		})
+
+		Context("when there is binding with this id without parameters", func() {
+			bindingParameters := make(map[string]interface{})
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(bindingParameters)
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return no parameters", func() {
+				result, err := client.GetBindingParameters(binding.ID, params)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result).To(Equal(bindingParameters))
+			})
+		})
+
+		Context("when there is no binding with this id", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						ResponseStatusCode: http.StatusNotFound},
+				}
+			})
+			It("should return 404", func() {
+				_, err := client.GetBindingParameters(binding.ID, params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path+binding.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+			})
+		})
+
+		Context("when bad gateway status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						ResponseStatusCode: http.StatusBadGateway},
+				}
+			})
+			It("should return an error with status code 502", func() {
+				_, err := client.GetBindingParameters(binding.ID, params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path+binding.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+			})
+		})
+
+		Context("when bad request status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						ResponseStatusCode: http.StatusBadRequest},
+				}
+			})
+			It("should return an error with status code 400", func() {
+				_, err := client.GetBindingParameters(binding.ID, params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path+binding.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+
+			})
+		})
+	})
+
 	Describe("Bind", func() {
 		Context("When valid binding is being created synchronously", func() {
 			BeforeEach(func() {

--- a/pkg/smclient/test/binding_test.go
+++ b/pkg/smclient/test/binding_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Binding test", func() {
 	})
 
 	Describe("Get service binding parameters", func() {
-		Context("when there is binding with this id with parameters", func() {
+		When("there is binding with this id with parameters", func() {
 			BeforeEach(func() {
 				responseBody, _ := json.Marshal(bindingParameters)
 				handlerDetails = []HandlerDetails{
@@ -150,7 +150,7 @@ var _ = Describe("Binding test", func() {
 			})
 		})
 
-		Context("when there is binding with this id without parameters", func() {
+		When("there is binding with this id without parameters", func() {
 			bindingParameters := make(map[string]interface{})
 			BeforeEach(func() {
 				responseBody, _ := json.Marshal(bindingParameters)
@@ -167,7 +167,7 @@ var _ = Describe("Binding test", func() {
 			})
 		})
 
-		Context("when there is no binding with this id", func() {
+		When("there is no binding with this id", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
@@ -182,7 +182,7 @@ var _ = Describe("Binding test", func() {
 			})
 		})
 
-		Context("when bad gateway status code is returned", func() {
+		When("bad gateway status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
@@ -197,7 +197,7 @@ var _ = Describe("Binding test", func() {
 			})
 		})
 
-		Context("when bad request status code is returned", func() {
+		When("bad request status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,

--- a/pkg/smclient/test/binding_test.go
+++ b/pkg/smclient/test/binding_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Binding test", func() {
 				responseBody, _ := json.Marshal(bindingParameters)
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL,
 						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
@@ -156,7 +156,7 @@ var _ = Describe("Binding test", func() {
 				responseBody, _ := json.Marshal(bindingParameters)
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL,
 						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
@@ -171,7 +171,7 @@ var _ = Describe("Binding test", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL,
 						ResponseStatusCode: http.StatusNotFound},
 				}
 			})
@@ -186,7 +186,7 @@ var _ = Describe("Binding test", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL,
 						ResponseStatusCode: http.StatusBadGateway},
 				}
 			})
@@ -201,7 +201,7 @@ var _ = Describe("Binding test", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL + "/",
+						Path: web.ServiceBindingsURL + "/" + binding.ID + web.ParametersURL,
 						ResponseStatusCode: http.StatusBadRequest},
 				}
 			})

--- a/pkg/smclient/test/binding_test.go
+++ b/pkg/smclient/test/binding_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Binding test", func() {
 			It("should return 404", func() {
 				_, err := client.GetBindingParameters(binding.ID, params)
 				Expect(err).Should(HaveOccurred())
-				verifyErrorMsg(err.Error(), handlerDetails[0].Path+binding.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
 			})
 		})
 
@@ -193,7 +193,7 @@ var _ = Describe("Binding test", func() {
 			It("should return an error with status code 502", func() {
 				_, err := client.GetBindingParameters(binding.ID, params)
 				Expect(err).Should(HaveOccurred())
-				verifyErrorMsg(err.Error(), handlerDetails[0].Path+binding.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
 			})
 		})
 
@@ -208,7 +208,7 @@ var _ = Describe("Binding test", func() {
 			It("should return an error with status code 400", func() {
 				_, err := client.GetBindingParameters(binding.ID, params)
 				Expect(err).Should(HaveOccurred())
-				verifyErrorMsg(err.Error(), handlerDetails[0].Path+binding.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
 
 			})
 		})

--- a/pkg/smclient/test/instance_test.go
+++ b/pkg/smclient/test/instance_test.go
@@ -135,6 +135,88 @@ var _ = Describe("Instance test", func() {
 		})
 	})
 
+	Describe("Get service instance parameters", func() {
+		Context("when there is instance with this id with parameters", func() {
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(instanceParameters)
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return parameters", func() {
+				result, err := client.GetInstanceParameters(instance.ID, params)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result).To(Equal(instanceParameters))
+			})
+		})
+
+		Context("when there is instance with this id without parameters", func() {
+			instanceParameters := make(map[string]interface{})
+			BeforeEach(func() {
+				responseBody, _ := json.Marshal(instanceParameters)
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
+				}
+			})
+			It("should return parameters", func() {
+				result, err := client.GetInstanceParameters(instance.ID, params)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result).To(Equal(instanceParameters))
+			})
+		})
+
+		Context("when there is no instance with this id", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						ResponseStatusCode: http.StatusNotFound},
+				}
+			})
+			It("should return 404", func() {
+				_, err := client.GetInstanceParameters(instance.ID, params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path+instance.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+			})
+		})
+
+		Context("when bad gateway status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						ResponseStatusCode: http.StatusBadGateway},
+				}
+			})
+			It("should return an error with status code 502", func() {
+				_, err := client.GetInstanceParameters(instance.ID, params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path+instance.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+			})
+		})
+
+		Context("when bad request status code is returned", func() {
+			BeforeEach(func() {
+				handlerDetails = []HandlerDetails{
+					{Method: http.MethodGet,
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						ResponseStatusCode: http.StatusBadRequest},
+				}
+			})
+			It("should return an error with status code 400", func() {
+				_, err := client.GetInstanceParameters(instance.ID, params)
+				Expect(err).Should(HaveOccurred())
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path+instance.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+
+			})
+		})
+	})
+
+
 	Describe("Provision", func() {
 		Context("When valid instance is being provisioned synchronously", func() {
 			BeforeEach(func() {

--- a/pkg/smclient/test/instance_test.go
+++ b/pkg/smclient/test/instance_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Instance test", func() {
 	})
 
 	Describe("Get service instance parameters", func() {
-		Context("when there is instance with this id with parameters", func() {
+		When("there is instance with this id with parameters", func() {
 			BeforeEach(func() {
 				responseBody, _ := json.Marshal(instanceParameters)
 				handlerDetails = []HandlerDetails{
@@ -152,7 +152,7 @@ var _ = Describe("Instance test", func() {
 			})
 		})
 
-		Context("when there is instance with this id without parameters", func() {
+		When("there is instance with this id without parameters", func() {
 			instanceParameters := make(map[string]interface{})
 			BeforeEach(func() {
 				responseBody, _ := json.Marshal(instanceParameters)
@@ -169,7 +169,7 @@ var _ = Describe("Instance test", func() {
 			})
 		})
 
-		Context("when there is no instance with this id", func() {
+		When("there is no instance with this id", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
@@ -184,7 +184,7 @@ var _ = Describe("Instance test", func() {
 			})
 		})
 
-		Context("when bad gateway status code is returned", func() {
+		When("bad gateway status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
@@ -199,7 +199,7 @@ var _ = Describe("Instance test", func() {
 			})
 		})
 
-		Context("when bad request status code is returned", func() {
+		When("bad request status code is returned", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,

--- a/pkg/smclient/test/instance_test.go
+++ b/pkg/smclient/test/instance_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Instance test", func() {
 				responseBody, _ := json.Marshal(instanceParameters)
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL,
 						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
@@ -158,7 +158,7 @@ var _ = Describe("Instance test", func() {
 				responseBody, _ := json.Marshal(instanceParameters)
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL,
 						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
@@ -173,7 +173,7 @@ var _ = Describe("Instance test", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL,
 						ResponseStatusCode: http.StatusNotFound},
 				}
 			})
@@ -188,7 +188,7 @@ var _ = Describe("Instance test", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL,
 						ResponseStatusCode: http.StatusBadGateway},
 				}
 			})
@@ -203,7 +203,7 @@ var _ = Describe("Instance test", func() {
 			BeforeEach(func() {
 				handlerDetails = []HandlerDetails{
 					{Method: http.MethodGet,
-						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL + "/",
+						Path: web.ServiceInstancesURL + "/"+ instance.ID + web.ParametersURL,
 						ResponseStatusCode: http.StatusBadRequest},
 				}
 			})
@@ -215,7 +215,6 @@ var _ = Describe("Instance test", func() {
 			})
 		})
 	})
-
 
 	Describe("Provision", func() {
 		Context("When valid instance is being provisioned synchronously", func() {

--- a/pkg/smclient/test/instance_test.go
+++ b/pkg/smclient/test/instance_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Instance test", func() {
 						ResponseBody: responseBody, ResponseStatusCode: http.StatusOK},
 				}
 			})
-			It("should return parameters", func() {
+			It("should return empty parameters", func() {
 				result, err := client.GetInstanceParameters(instance.ID, params)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(result).To(Equal(instanceParameters))
@@ -180,7 +180,7 @@ var _ = Describe("Instance test", func() {
 			It("should return 404", func() {
 				_, err := client.GetInstanceParameters(instance.ID, params)
 				Expect(err).Should(HaveOccurred())
-				verifyErrorMsg(err.Error(), handlerDetails[0].Path+instance.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
 			})
 		})
 
@@ -195,7 +195,7 @@ var _ = Describe("Instance test", func() {
 			It("should return an error with status code 502", func() {
 				_, err := client.GetInstanceParameters(instance.ID, params)
 				Expect(err).Should(HaveOccurred())
-				verifyErrorMsg(err.Error(), handlerDetails[0].Path+instance.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
 			})
 		})
 
@@ -210,7 +210,7 @@ var _ = Describe("Instance test", func() {
 			It("should return an error with status code 400", func() {
 				_, err := client.GetInstanceParameters(instance.ID, params)
 				Expect(err).Should(HaveOccurred())
-				verifyErrorMsg(err.Error(), handlerDetails[0].Path+instance.ID, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
+				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
 
 			})
 		})

--- a/pkg/smclient/test/smclient_suite_test.go
+++ b/pkg/smclient/test/smclient_suite_test.go
@@ -89,6 +89,9 @@ var (
 		Context:       json.RawMessage("{}"),
 	}
 
+	instanceParameters = map[string]interface{}{"param1":"value1","param2":"value2"}
+	bindingParameters = map[string]interface{}{"param1":"value1","param2":"value2"}
+
 	binding = &types.ServiceBinding{
 		ID:                "instanceID",
 		Name:              "instance1",


### PR DESCRIPTION


## Motivation
In many cases services require input parameters for service instances or service bindings creation. These parameters are used by the broker in the provisioning process.

This information is valuable to the instance owner and might be required in order to manage the instance.

Currently service manager does not store this information and thus it cannot be retrieved.

BLI: https://jtrack.wdf.sap.corp/browse/SAPCPCFS-17437?src=confmacro


#### Pull Request status
Use checklists as a means to represent the status of your Pull Request.

For example:

- [x] Initial implementation
- [ ] Refactoring
- [x] Unit tests
- [ ] Integration tests

