### PR TITLE
Platform cascade delete

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,7 +21,8 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:8acbbe8e0bb2411300963a0186650d42e2ca5a261e319b15ca7d187245b9841b"
+  branch = "master"
+  digest = "1:4b1c927b2e21c2c6985a665dcc8e4e126977c8801621f5aafa79121ea95c6526"
   name = "github.com/Peripli/service-manager"
   packages = [
     "pkg/health",
@@ -34,8 +35,7 @@
     "pkg/web",
   ]
   pruneopts = "UT"
-  revision = "8adb0c510e5959124b4f1c7447b26fa6d6329205"
-  version = "v0.10.3"
+  revision = "7d575eb39a5aa32d3d9efe57f999e091de66982f"
 
 [[projects]]
   digest = "1:3076a0751f5648f3ab1838abfba18bc5bf514cde7e3957500b62fba90633479a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  version = "0.16.7"
+  branch = "support-cascade-delete"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = ["gopkg.in/fsnotify.v1"]
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  branch = "support-cascade-delete"
+  branch = "master"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
  [[override]]

--- a/docs/commands/delete-platform.md
+++ b/docs/commands/delete-platform.md
@@ -26,7 +26,7 @@ delete-platform, dp
 <details>
   <summary>cascade-delete</summary>
   <p>
-    <code>--cascade-delete</code> 
+    <code>--cascade</code> 
   </p>
   <p>
     Cascade delete for <i>delete-platform</i> command. 
@@ -60,7 +60,7 @@ delete-platform, dp
 Platform with name: sample-platform successfully deleted
 ```
 ```bash
-> smctl delete-platform sample-platform --cascade-delete
+> smctl delete-platform sample-platform --cascade
 
 Cascade delete successfully scheduled for platform: sample-platform. To see status of the operation use:
 smctl status /v1/platforms/baea022b-64c0-43d4-a9b0-e1ae64af51cd/operations/f8ca64af-e889-4a45-ad41-f1baa2e427c2

--- a/docs/commands/delete-platform.md
+++ b/docs/commands/delete-platform.md
@@ -23,6 +23,15 @@ delete-platform, dp
     Help for <i>delete-platform</i> command. 
   </p>
 </details>
+<details>
+  <summary>cascade-delete</summary>
+  <p>
+    <code>--cascade-delete</code> 
+  </p>
+  <p>
+    Cascade delete for <i>delete-platform</i> command. 
+  </p>
+</details>
 
 ## Global Flags
 <details>
@@ -49,4 +58,10 @@ delete-platform, dp
 > smctl delete-platform sample-platform
 
 Platform with name: sample-platform successfully deleted
+```
+```bash
+> smctl delete-platform sample-platform --cascade-delete
+
+Cascade delete successfully scheduled for platform: sample-platform. To see status of the operation use:
+smctl status /v1/platforms/baea022b-64c0-43d4-a9b0-e1ae64af51cd/operations/f8ca64af-e889-4a45-ad41-f1baa2e427c2
 ```

--- a/internal/cmd/binding/get_binding_test.go
+++ b/internal/cmd/binding/get_binding_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Get binding command test", func() {
 				client.ListBindingsReturns(response, nil)
 			})
 
-			It("should return parameters both bindings", func() {
+			It("should print parameters for both bindings", func() {
 				client.GetBindingParametersReturnsOnCall(0, bindingParameters1 , nil)
 				client.GetBindingParametersReturnsOnCall(1, bindingParameters2, nil)
 				err := executeWithArgs("binding1", "--show-binding-params")

--- a/internal/cmd/instance/get_instance_test.go
+++ b/internal/cmd/instance/get_instance_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Get instance command test", func() {
 				response = &types.ServiceInstances{ServiceInstances: []types.ServiceInstance{instance, instance2}, Vertical: true}
 				client.ListInstancesReturns(response, nil)
 			})
-			It("should return parameters for both instances", func() {
+			It("should print parameters for both instances", func() {
 				client.GetInstanceParametersReturnsOnCall(0, instanceParameters1, nil)
 				client.GetInstanceParametersReturnsOnCall(1, instanceParameters2, nil)
 				err := executeWithArgs("instance1", "--show-instance-params")

--- a/internal/cmd/platform/delete_platform.go
+++ b/internal/cmd/platform/delete_platform.go
@@ -97,7 +97,7 @@ func (dpc *DeletePlatformCmd) cascadeDelete() error {
 	dpc.Parameters.GeneralParams = append(dpc.Parameters.GeneralParams, fmt.Sprintf("%s=%s", web.QueryParamAsync, "true"))
 
 	for _, platform := range platforms.Platforms {
-		location, err := dpc.Client.CascadeDeletePlatform(platform.ID, &dpc.Parameters)
+		location, err := dpc.Client.DeletePlatform(platform.ID, &dpc.Parameters)
 		if err != nil {
 			// The platform could be deleted after List and before Delete
 			if strings.Contains(err.Error(), "StatusCode: 404") {

--- a/internal/cmd/platform/delete_platform.go
+++ b/internal/cmd/platform/delete_platform.go
@@ -34,9 +34,9 @@ import (
 type DeletePlatformCmd struct {
 	*cmd.Context
 
-	input             io.Reader
-	force             bool
-	cascadeDeleteFlag *bool
+	input       io.Reader
+	force       bool
+	cascadeFlag *bool
 
 	name string
 }
@@ -48,7 +48,7 @@ func NewDeletePlatformCmd(context *cmd.Context, input io.Reader) *DeletePlatform
 
 // Validate validates command's arguments
 func (dpc *DeletePlatformCmd) Validate(args []string) error {
-	if len(args) != 1 || len(args[0]) < 1{
+	if len(args) != 1 || len(args[0]) < 1 {
 		return fmt.Errorf("single [name] is required")
 	}
 
@@ -60,7 +60,7 @@ func (dpc *DeletePlatformCmd) Validate(args []string) error {
 // Run runs the command's logic
 func (dpc *DeletePlatformCmd) Run() error {
 
-	if *dpc.cascadeDeleteFlag {
+	if *dpc.cascadeFlag {
 		return dpc.cascadeDelete()
 	}
 
@@ -107,7 +107,7 @@ func (dpc *DeletePlatformCmd) cascadeDelete() error {
 			continue
 		}
 		if len(location) != 0 {
-			cmd.CommonHandleAsyncExecution(dpc.Context, location, fmt.Sprintf("Cascade delete successfully scheduled for platform id: %s . " +
+			cmd.CommonHandleAsyncExecution(dpc.Context, location, fmt.Sprintf("Cascade delete successfully scheduled for platform id: %s . "+
 				"To see status of the operation use:\n", platform.ID))
 			continue
 		}
@@ -148,7 +148,7 @@ func (dpc *DeletePlatformCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(dpc, dpc.Context),
 		RunE:    cmd.RunE(dpc),
 	}
-	dpc.cascadeDeleteFlag = result.PersistentFlags().Bool("cascade-delete", false, "Cascade delete platform with all the associated resources")
+	dpc.cascadeFlag = result.PersistentFlags().Bool("cascade", false, "Cascade delete platform with all the associated resources")
 	result.Flags().BoolVarP(&dpc.force, "force", "f", false, "Force delete without confirmation")
 	cmd.AddCommonQueryFlag(result.Flags(), &dpc.Parameters)
 

--- a/internal/cmd/platform/delete_platform_test.go
+++ b/internal/cmd/platform/delete_platform_test.go
@@ -127,8 +127,8 @@ var _ = Describe("Delete platforms command test", func() {
 	Describe("cascade delete platform", func() {
 
 		platform1 := types.Platform{
-			Name:       "platform1",
-			ID:         "id1",
+			Name: "platform1",
+			ID:   "id1",
 		}
 
 		When("platform exists", func() {
@@ -137,7 +137,7 @@ var _ = Describe("Delete platforms command test", func() {
 				location := "/v1/platforms/id1/operations/1a3e795d-819c-4661-89b5-344adb2ec26a"
 
 				client.CascadeDeletePlatformReturns(location, nil)
-				err := executeWithArgs([]string{platform1.Name, "--cascade-delete", "-f"})
+				err := executeWithArgs([]string{platform1.Name, "--cascade", "-f"})
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buffer.String()).To(ContainSubstring("Cascade delete successfully scheduled"))
@@ -147,7 +147,7 @@ var _ = Describe("Delete platforms command test", func() {
 		When("platform does not exist", func() {
 			It("should print platform(s) not found", func() {
 				client.ListPlatformsReturns(&types.Platforms{}, nil)
-				err := executeWithArgs([]string{"non-existing-name", "--cascade-delete", "-f"})
+				err := executeWithArgs([]string{"non-existing-name", "--cascade", "-f"})
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buffer.String()).To(ContainSubstring("Platform(s) not found."))
@@ -161,7 +161,7 @@ var _ = Describe("Delete platforms command test", func() {
 				expectedError := util.HandleResponseError(&http.Response{Body: body, StatusCode: http.StatusInternalServerError})
 				client.CascadeDeletePlatformReturns("", expectedError)
 				promptBuffer.WriteString("y")
-				_ = executeWithArgs([]string{platform1.Name, "--cascade-delete"})
+				_ = executeWithArgs([]string{platform1.Name, "--cascade"})
 
 				Expect(buffer.String()).To(ContainSubstring("Could not cascade-delete platform"))
 			})
@@ -169,7 +169,7 @@ var _ = Describe("Delete platforms command test", func() {
 
 		When("no platform name is provided", func() {
 			It("should print required arguments", func() {
-				err := executeWithArgs([]string{"", "--cascade-delete"})
+				err := executeWithArgs([]string{"", "--cascade"})
 
 				Expect(err).Should(HaveOccurred())
 				Expect(err).To(MatchError("single [name] is required"))

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -46,7 +46,7 @@ type Client interface {
 	ListPlatforms(*query.Parameters) (*types.Platforms, error)
 	UpdatePlatform(string, *types.Platform, *query.Parameters) (*types.Platform, error)
 	DeletePlatforms(*query.Parameters) error
-	CascadeDeletePlatform(*query.Parameters) (string, error)
+	CascadeDeletePlatform(id string, q *query.Parameters) (string, error)
 
 	RegisterBroker(*types.Broker, *query.Parameters) (*types.Broker, string, error)
 	GetBrokerByID(string, *query.Parameters) (*types.Broker, error)
@@ -380,8 +380,8 @@ func (client *serviceManagerClient) DeletePlatforms(q *query.Parameters) error {
 	return err
 }
 
-func (client *serviceManagerClient) CascadeDeletePlatform(q *query.Parameters) (string, error) {
-	location, err := client.delete(web.PlatformsURL, q)
+func (client *serviceManagerClient) CascadeDeletePlatform(id string, q *query.Parameters) (string, error) {
+	location, err := client.delete(web.PlatformsURL + "/" + id, q)
 	return location, err
 }
 

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -46,7 +46,7 @@ type Client interface {
 	ListPlatforms(*query.Parameters) (*types.Platforms, error)
 	UpdatePlatform(string, *types.Platform, *query.Parameters) (*types.Platform, error)
 	DeletePlatforms(*query.Parameters) error
-	CascadeDeletePlatform(id string, q *query.Parameters) (string, error)
+	DeletePlatform(id string, q *query.Parameters) (string, error)
 
 	RegisterBroker(*types.Broker, *query.Parameters) (*types.Broker, string, error)
 	GetBrokerByID(string, *query.Parameters) (*types.Broker, error)
@@ -380,7 +380,7 @@ func (client *serviceManagerClient) DeletePlatforms(q *query.Parameters) error {
 	return err
 }
 
-func (client *serviceManagerClient) CascadeDeletePlatform(id string, q *query.Parameters) (string, error) {
+func (client *serviceManagerClient) DeletePlatform(id string, q *query.Parameters) (string, error) {
 	location, err := client.delete(web.PlatformsURL + "/" + id, q)
 	return location, err
 }

--- a/pkg/smclient/client.go
+++ b/pkg/smclient/client.go
@@ -46,6 +46,7 @@ type Client interface {
 	ListPlatforms(*query.Parameters) (*types.Platforms, error)
 	UpdatePlatform(string, *types.Platform, *query.Parameters) (*types.Platform, error)
 	DeletePlatforms(*query.Parameters) error
+	CascadeDeletePlatform(*query.Parameters) (string, error)
 
 	RegisterBroker(*types.Broker, *query.Parameters) (*types.Broker, string, error)
 	GetBrokerByID(string, *query.Parameters) (*types.Broker, error)
@@ -377,6 +378,11 @@ func (client *serviceManagerClient) DeleteBroker(id string, q *query.Parameters)
 func (client *serviceManagerClient) DeletePlatforms(q *query.Parameters) error {
 	_, err := client.delete(web.PlatformsURL, q)
 	return err
+}
+
+func (client *serviceManagerClient) CascadeDeletePlatform(q *query.Parameters) (string, error) {
+	location, err := client.delete(web.PlatformsURL, q)
+	return location, err
 }
 
 func (client *serviceManagerClient) DeleteVisibilities(q *query.Parameters) error {

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -44,6 +44,19 @@ type FakeClient struct {
 		result1 *http.Response
 		result2 error
 	}
+	CascadeDeletePlatformStub        func(*query.Parameters) (string, error)
+	cascadeDeletePlatformMutex       sync.RWMutex
+	cascadeDeletePlatformArgsForCall []struct {
+		arg1 *query.Parameters
+	}
+	cascadeDeletePlatformReturns struct {
+		result1 string
+		result2 error
+	}
+	cascadeDeletePlatformReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	DeleteBrokerStub        func(string, *query.Parameters) (string, error)
 	deleteBrokerMutex       sync.RWMutex
 	deleteBrokerArgsForCall []struct {
@@ -580,6 +593,69 @@ func (fake *FakeClient) CallReturnsOnCall(i int, result1 *http.Response, result2
 	}
 	fake.callReturnsOnCall[i] = struct {
 		result1 *http.Response
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) CascadeDeletePlatform(arg1 *query.Parameters) (string, error) {
+	fake.cascadeDeletePlatformMutex.Lock()
+	ret, specificReturn := fake.cascadeDeletePlatformReturnsOnCall[len(fake.cascadeDeletePlatformArgsForCall)]
+	fake.cascadeDeletePlatformArgsForCall = append(fake.cascadeDeletePlatformArgsForCall, struct {
+		arg1 *query.Parameters
+	}{arg1})
+	fake.recordInvocation("CascadeDeletePlatform", []interface{}{arg1})
+	fake.cascadeDeletePlatformMutex.Unlock()
+	if fake.CascadeDeletePlatformStub != nil {
+		return fake.CascadeDeletePlatformStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.cascadeDeletePlatformReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) CascadeDeletePlatformCallCount() int {
+	fake.cascadeDeletePlatformMutex.RLock()
+	defer fake.cascadeDeletePlatformMutex.RUnlock()
+	return len(fake.cascadeDeletePlatformArgsForCall)
+}
+
+func (fake *FakeClient) CascadeDeletePlatformCalls(stub func(*query.Parameters) (string, error)) {
+	fake.cascadeDeletePlatformMutex.Lock()
+	defer fake.cascadeDeletePlatformMutex.Unlock()
+	fake.CascadeDeletePlatformStub = stub
+}
+
+func (fake *FakeClient) CascadeDeletePlatformArgsForCall(i int) *query.Parameters {
+	fake.cascadeDeletePlatformMutex.RLock()
+	defer fake.cascadeDeletePlatformMutex.RUnlock()
+	argsForCall := fake.cascadeDeletePlatformArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) CascadeDeletePlatformReturns(result1 string, result2 error) {
+	fake.cascadeDeletePlatformMutex.Lock()
+	defer fake.cascadeDeletePlatformMutex.Unlock()
+	fake.CascadeDeletePlatformStub = nil
+	fake.cascadeDeletePlatformReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) CascadeDeletePlatformReturnsOnCall(i int, result1 string, result2 error) {
+	fake.cascadeDeletePlatformMutex.Lock()
+	defer fake.cascadeDeletePlatformMutex.Unlock()
+	fake.CascadeDeletePlatformStub = nil
+	if fake.cascadeDeletePlatformReturnsOnCall == nil {
+		fake.cascadeDeletePlatformReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.cascadeDeletePlatformReturnsOnCall[i] = struct {
+		result1 string
 		result2 error
 	}{result1, result2}
 }
@@ -2445,6 +2521,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.bindMutex.RUnlock()
 	fake.callMutex.RLock()
 	defer fake.callMutex.RUnlock()
+	fake.cascadeDeletePlatformMutex.RLock()
+	defer fake.cascadeDeletePlatformMutex.RUnlock()
 	fake.deleteBrokerMutex.RLock()
 	defer fake.deleteBrokerMutex.RUnlock()
 	fake.deletePlatformsMutex.RLock()

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -44,10 +44,11 @@ type FakeClient struct {
 		result1 *http.Response
 		result2 error
 	}
-	CascadeDeletePlatformStub        func(*query.Parameters) (string, error)
+	CascadeDeletePlatformStub        func(string, *query.Parameters) (string, error)
 	cascadeDeletePlatformMutex       sync.RWMutex
 	cascadeDeletePlatformArgsForCall []struct {
-		arg1 *query.Parameters
+		arg1 string
+		arg2 *query.Parameters
 	}
 	cascadeDeletePlatformReturns struct {
 		result1 string
@@ -597,16 +598,17 @@ func (fake *FakeClient) CallReturnsOnCall(i int, result1 *http.Response, result2
 	}{result1, result2}
 }
 
-func (fake *FakeClient) CascadeDeletePlatform(arg1 *query.Parameters) (string, error) {
+func (fake *FakeClient) CascadeDeletePlatform(arg1 string, arg2 *query.Parameters) (string, error) {
 	fake.cascadeDeletePlatformMutex.Lock()
 	ret, specificReturn := fake.cascadeDeletePlatformReturnsOnCall[len(fake.cascadeDeletePlatformArgsForCall)]
 	fake.cascadeDeletePlatformArgsForCall = append(fake.cascadeDeletePlatformArgsForCall, struct {
-		arg1 *query.Parameters
-	}{arg1})
-	fake.recordInvocation("CascadeDeletePlatform", []interface{}{arg1})
+		arg1 string
+		arg2 *query.Parameters
+	}{arg1, arg2})
+	fake.recordInvocation("CascadeDeletePlatform", []interface{}{arg1, arg2})
 	fake.cascadeDeletePlatformMutex.Unlock()
 	if fake.CascadeDeletePlatformStub != nil {
-		return fake.CascadeDeletePlatformStub(arg1)
+		return fake.CascadeDeletePlatformStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -621,17 +623,17 @@ func (fake *FakeClient) CascadeDeletePlatformCallCount() int {
 	return len(fake.cascadeDeletePlatformArgsForCall)
 }
 
-func (fake *FakeClient) CascadeDeletePlatformCalls(stub func(*query.Parameters) (string, error)) {
+func (fake *FakeClient) CascadeDeletePlatformCalls(stub func(string, *query.Parameters) (string, error)) {
 	fake.cascadeDeletePlatformMutex.Lock()
 	defer fake.cascadeDeletePlatformMutex.Unlock()
 	fake.CascadeDeletePlatformStub = stub
 }
 
-func (fake *FakeClient) CascadeDeletePlatformArgsForCall(i int) *query.Parameters {
+func (fake *FakeClient) CascadeDeletePlatformArgsForCall(i int) (string, *query.Parameters) {
 	fake.cascadeDeletePlatformMutex.RLock()
 	defer fake.cascadeDeletePlatformMutex.RUnlock()
 	argsForCall := fake.cascadeDeletePlatformArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) CascadeDeletePlatformReturns(result1 string, result2 error) {

--- a/pkg/smclient/smclientfakes/fake_client.go
+++ b/pkg/smclient/smclientfakes/fake_client.go
@@ -44,20 +44,6 @@ type FakeClient struct {
 		result1 *http.Response
 		result2 error
 	}
-	CascadeDeletePlatformStub        func(string, *query.Parameters) (string, error)
-	cascadeDeletePlatformMutex       sync.RWMutex
-	cascadeDeletePlatformArgsForCall []struct {
-		arg1 string
-		arg2 *query.Parameters
-	}
-	cascadeDeletePlatformReturns struct {
-		result1 string
-		result2 error
-	}
-	cascadeDeletePlatformReturnsOnCall map[int]struct {
-		result1 string
-		result2 error
-	}
 	DeleteBrokerStub        func(string, *query.Parameters) (string, error)
 	deleteBrokerMutex       sync.RWMutex
 	deleteBrokerArgsForCall []struct {
@@ -69,6 +55,20 @@ type FakeClient struct {
 		result2 error
 	}
 	deleteBrokerReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
+	DeletePlatformStub        func(string, *query.Parameters) (string, error)
+	deletePlatformMutex       sync.RWMutex
+	deletePlatformArgsForCall []struct {
+		arg1 string
+		arg2 *query.Parameters
+	}
+	deletePlatformReturns struct {
+		result1 string
+		result2 error
+	}
+	deletePlatformReturnsOnCall map[int]struct {
 		result1 string
 		result2 error
 	}
@@ -598,70 +598,6 @@ func (fake *FakeClient) CallReturnsOnCall(i int, result1 *http.Response, result2
 	}{result1, result2}
 }
 
-func (fake *FakeClient) CascadeDeletePlatform(arg1 string, arg2 *query.Parameters) (string, error) {
-	fake.cascadeDeletePlatformMutex.Lock()
-	ret, specificReturn := fake.cascadeDeletePlatformReturnsOnCall[len(fake.cascadeDeletePlatformArgsForCall)]
-	fake.cascadeDeletePlatformArgsForCall = append(fake.cascadeDeletePlatformArgsForCall, struct {
-		arg1 string
-		arg2 *query.Parameters
-	}{arg1, arg2})
-	fake.recordInvocation("CascadeDeletePlatform", []interface{}{arg1, arg2})
-	fake.cascadeDeletePlatformMutex.Unlock()
-	if fake.CascadeDeletePlatformStub != nil {
-		return fake.CascadeDeletePlatformStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.cascadeDeletePlatformReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeClient) CascadeDeletePlatformCallCount() int {
-	fake.cascadeDeletePlatformMutex.RLock()
-	defer fake.cascadeDeletePlatformMutex.RUnlock()
-	return len(fake.cascadeDeletePlatformArgsForCall)
-}
-
-func (fake *FakeClient) CascadeDeletePlatformCalls(stub func(string, *query.Parameters) (string, error)) {
-	fake.cascadeDeletePlatformMutex.Lock()
-	defer fake.cascadeDeletePlatformMutex.Unlock()
-	fake.CascadeDeletePlatformStub = stub
-}
-
-func (fake *FakeClient) CascadeDeletePlatformArgsForCall(i int) (string, *query.Parameters) {
-	fake.cascadeDeletePlatformMutex.RLock()
-	defer fake.cascadeDeletePlatformMutex.RUnlock()
-	argsForCall := fake.cascadeDeletePlatformArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeClient) CascadeDeletePlatformReturns(result1 string, result2 error) {
-	fake.cascadeDeletePlatformMutex.Lock()
-	defer fake.cascadeDeletePlatformMutex.Unlock()
-	fake.CascadeDeletePlatformStub = nil
-	fake.cascadeDeletePlatformReturns = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) CascadeDeletePlatformReturnsOnCall(i int, result1 string, result2 error) {
-	fake.cascadeDeletePlatformMutex.Lock()
-	defer fake.cascadeDeletePlatformMutex.Unlock()
-	fake.CascadeDeletePlatformStub = nil
-	if fake.cascadeDeletePlatformReturnsOnCall == nil {
-		fake.cascadeDeletePlatformReturnsOnCall = make(map[int]struct {
-			result1 string
-			result2 error
-		})
-	}
-	fake.cascadeDeletePlatformReturnsOnCall[i] = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeClient) DeleteBroker(arg1 string, arg2 *query.Parameters) (string, error) {
 	fake.deleteBrokerMutex.Lock()
 	ret, specificReturn := fake.deleteBrokerReturnsOnCall[len(fake.deleteBrokerArgsForCall)]
@@ -721,6 +657,70 @@ func (fake *FakeClient) DeleteBrokerReturnsOnCall(i int, result1 string, result2
 		})
 	}
 	fake.deleteBrokerReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) DeletePlatform(arg1 string, arg2 *query.Parameters) (string, error) {
+	fake.deletePlatformMutex.Lock()
+	ret, specificReturn := fake.deletePlatformReturnsOnCall[len(fake.deletePlatformArgsForCall)]
+	fake.deletePlatformArgsForCall = append(fake.deletePlatformArgsForCall, struct {
+		arg1 string
+		arg2 *query.Parameters
+	}{arg1, arg2})
+	fake.recordInvocation("DeletePlatform", []interface{}{arg1, arg2})
+	fake.deletePlatformMutex.Unlock()
+	if fake.DeletePlatformStub != nil {
+		return fake.DeletePlatformStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.deletePlatformReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) DeletePlatformCallCount() int {
+	fake.deletePlatformMutex.RLock()
+	defer fake.deletePlatformMutex.RUnlock()
+	return len(fake.deletePlatformArgsForCall)
+}
+
+func (fake *FakeClient) DeletePlatformCalls(stub func(string, *query.Parameters) (string, error)) {
+	fake.deletePlatformMutex.Lock()
+	defer fake.deletePlatformMutex.Unlock()
+	fake.DeletePlatformStub = stub
+}
+
+func (fake *FakeClient) DeletePlatformArgsForCall(i int) (string, *query.Parameters) {
+	fake.deletePlatformMutex.RLock()
+	defer fake.deletePlatformMutex.RUnlock()
+	argsForCall := fake.deletePlatformArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) DeletePlatformReturns(result1 string, result2 error) {
+	fake.deletePlatformMutex.Lock()
+	defer fake.deletePlatformMutex.Unlock()
+	fake.DeletePlatformStub = nil
+	fake.deletePlatformReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) DeletePlatformReturnsOnCall(i int, result1 string, result2 error) {
+	fake.deletePlatformMutex.Lock()
+	defer fake.deletePlatformMutex.Unlock()
+	fake.DeletePlatformStub = nil
+	if fake.deletePlatformReturnsOnCall == nil {
+		fake.deletePlatformReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.deletePlatformReturnsOnCall[i] = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
@@ -2523,10 +2523,10 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.bindMutex.RUnlock()
 	fake.callMutex.RLock()
 	defer fake.callMutex.RUnlock()
-	fake.cascadeDeletePlatformMutex.RLock()
-	defer fake.cascadeDeletePlatformMutex.RUnlock()
 	fake.deleteBrokerMutex.RLock()
 	defer fake.deleteBrokerMutex.RUnlock()
+	fake.deletePlatformMutex.RLock()
+	defer fake.deletePlatformMutex.RUnlock()
 	fake.deletePlatformsMutex.RLock()
 	defer fake.deletePlatformsMutex.RUnlock()
 	fake.deleteVisibilitiesMutex.RLock()

--- a/pkg/smclient/test/platform_test.go
+++ b/pkg/smclient/test/platform_test.go
@@ -285,7 +285,7 @@ var _ = Describe("Platform test", func() {
 				}
 			})
 			It("should return location of operation scheduled for platform cascade delete", func() {
-				location, err := client.CascadeDeletePlatform(platform.ID,  params)
+				location, err := client.DeletePlatform(platform.ID,  params)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(location).Should(Equal(locationHeader))
@@ -300,7 +300,7 @@ var _ = Describe("Platform test", func() {
 				}
 			})
 			It("should return error with non-expected status code, location should be nil", func() {
-				location, err := client.CascadeDeletePlatform(platform.ID, params)
+				location, err := client.DeletePlatform(platform.ID, params)
 				Expect(err).Should(HaveOccurred())
 				Expect(location).Should(Equal(""))
 				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
@@ -315,7 +315,7 @@ var _ = Describe("Platform test", func() {
 				}
 			})
 			It("should return 404", func() {
-				location, err := client.CascadeDeletePlatform(platform.ID, params)
+				location, err := client.DeletePlatform(platform.ID, params)
 				Expect(err).Should(HaveOccurred())
 				Expect(location).Should(Equal(""))
 				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)

--- a/pkg/smclient/test/platform_test.go
+++ b/pkg/smclient/test/platform_test.go
@@ -279,13 +279,13 @@ var _ = Describe("Platform test", func() {
 		When("a platform exists", func() {
 			var locationHeader string
 			BeforeEach(func() {
-				locationHeader = "/v1/platforms/dac3db36-df28-4b06-a5bd-dcc38a918c8c/operations/1a3e795d-819c-4661-89b5-344adb2ec26a"
+				locationHeader = "/v1/platforms/platformID/operations/1a3e795d-819c-4661-89b5-344adb2ec26a"
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: web.PlatformsURL, ResponseStatusCode: http.StatusAccepted, Headers: map[string]string{"Location": locationHeader}},
+					{Method: http.MethodDelete, Path: web.PlatformsURL + "/"+ platform.ID, ResponseStatusCode: http.StatusAccepted, Headers: map[string]string{"Location": locationHeader}},
 				}
 			})
 			It("should return location of operation scheduled for platform cascade delete", func() {
-				location, err := client.CascadeDeletePlatform(params)
+				location, err := client.CascadeDeletePlatform(platform.ID,  params)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(location).Should(Equal(locationHeader))
@@ -296,11 +296,11 @@ var _ = Describe("Platform test", func() {
 			BeforeEach(func() {
 				responseBody := []byte("{}")
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
+					{Method: http.MethodDelete, Path: web.PlatformsURL + "/"+ platform.ID, ResponseBody: responseBody, ResponseStatusCode: http.StatusCreated},
 				}
 			})
 			It("should return error with non-expected status code, location should be nil", func() {
-				location, err := client.CascadeDeletePlatform(params)
+				location, err := client.CascadeDeletePlatform(platform.ID, params)
 				Expect(err).Should(HaveOccurred())
 				Expect(location).Should(Equal(""))
 				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)
@@ -311,11 +311,11 @@ var _ = Describe("Platform test", func() {
 			BeforeEach(func() {
 				responseBody := []byte(`{ "description": "Resource not found" }`)
 				handlerDetails = []HandlerDetails{
-					{Method: http.MethodDelete, Path: web.PlatformsURL, ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
+					{Method: http.MethodDelete, Path: web.PlatformsURL + "/"+ platform.ID, ResponseBody: responseBody, ResponseStatusCode: http.StatusNotFound},
 				}
 			})
 			It("should return 404", func() {
-				location, err := client.CascadeDeletePlatform(params)
+				location, err := client.CascadeDeletePlatform(platform.ID, params)
 				Expect(err).Should(HaveOccurred())
 				Expect(location).Should(Equal(""))
 				verifyErrorMsg(err.Error(), handlerDetails[0].Path, handlerDetails[0].ResponseBody, handlerDetails[0].ResponseStatusCode)


### PR DESCRIPTION


## Motivation
Cleanup service instances and binding on platform unregistration

In cases where subaccount scoped platform is not reachable (e.g. K8S cluster was deleted) and service instances and bindings were not properly deleted, brokers are not notified and resources were not deallocated, which may lead resource exhaustion and unnecessary costs. 

The goal of this user story is to enhance the unregisteration flow of SA scoped platform to allow structured cleanup of its resources and avoid waste of resources and money.

https://jtrack.wdf.sap.corp/browse/SAPCPCFS-17435

#### Pull Request status
Use checklists as a means to represent the status of your Pull Request.

For example:

- [x] Initial implementation
- [ ] Refactoring
- [x] Unit tests
- [ ] Integration tests

