### PR TITLE
propagate params in all requests to SM

### DIFF
--- a/internal/cmd/binding/bind.go
+++ b/internal/cmd/binding/bind.go
@@ -81,6 +81,7 @@ func (bc *BindCmd) Run() error {
 			FieldQuery: []string{
 				fmt.Sprintf("name eq '%s'", bc.instanceName),
 			},
+			GeneralParams: bc.Parameters.GeneralParams,
 		})
 		if err != nil {
 			return err

--- a/internal/cmd/binding/get_binding.go
+++ b/internal/cmd/binding/get_binding.go
@@ -32,8 +32,8 @@ import (
 type GetBindingCmd struct {
 	*cmd.Context
 
-	bindingName  string
-	outputFormat output.Format
+	bindingName   string
+	outputFormat  output.Format
 	bindingParams *bool
 }
 
@@ -48,6 +48,7 @@ func (gb *GetBindingCmd) Run() error {
 		FieldQuery: []string{
 			fmt.Sprintf("name eq '%s'", gb.bindingName),
 		},
+		GeneralParams: gb.Parameters.GeneralParams,
 	})
 	if err != nil {
 		return err
@@ -89,7 +90,6 @@ func (gb *GetBindingCmd) Run() error {
 	return nil
 }
 
-
 func (gb *GetBindingCmd) printParameters(bindings *types.ServiceBindings) error {
 	for _, binding := range bindings.ServiceBindings {
 		parameters, err := gb.Client.GetBindingParameters(binding.ID, &gb.Parameters)
@@ -107,16 +107,14 @@ func (gb *GetBindingCmd) printParameters(bindings *types.ServiceBindings) error 
 			continue
 		}
 
-
 		output.PrintMessage(gb.Output, "Showing configuration parameters for service binding id: %s \n", binding.ID)
 		output.PrintMessage(gb.Output, "The parameters: \n")
-		output.PrintMessage(gb.Output, "%s \n\n ",output.PrintParameters(parameters))
+		output.PrintMessage(gb.Output, "%s \n\n ", output.PrintParameters(parameters))
 	}
 
 	output.Println(gb.Output)
 	return nil
 }
-
 
 // Validate validates command's arguments
 func (gb *GetBindingCmd) Validate(args []string) error {
@@ -149,7 +147,7 @@ func (gb *GetBindingCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		PreRunE: prepare(gb, gb.Context),
 		RunE:    cmd.RunE(gb),
 	}
-	gb.bindingParams = result.PersistentFlags().Bool("show-binding-params",false , "Show the service binding configuration parameters")
+	gb.bindingParams = result.PersistentFlags().Bool("show-binding-params", false, "Show the service binding configuration parameters")
 	cmd.AddFormatFlag(result.Flags())
 	cmd.AddCommonQueryFlag(result.Flags(), &gb.Parameters)
 

--- a/internal/cmd/binding/unbind.go
+++ b/internal/cmd/binding/unbind.go
@@ -83,6 +83,7 @@ func (ubc *UnbindCmd) Run() error {
 			FieldQuery: []string{
 				fmt.Sprintf("name eq '%s'", ubc.instanceName),
 			},
+			GeneralParams: ubc.Parameters.GeneralParams,
 		})
 		if err != nil {
 			return err
@@ -99,6 +100,7 @@ func (ubc *UnbindCmd) Run() error {
 				fmt.Sprintf("name eq '%s'", ubc.bindingName),
 				fmt.Sprintf("service_instance_id eq '%s'", instanceToUnbind.ServiceInstances[0].ID),
 			},
+			GeneralParams: ubc.Parameters.GeneralParams,
 		})
 		if err != nil {
 			return err

--- a/internal/cmd/broker/delete_broker.go
+++ b/internal/cmd/broker/delete_broker.go
@@ -59,6 +59,7 @@ func (dbc *DeleteBrokerCmd) Run() error {
 		FieldQuery: []string{
 			fmt.Sprintf("name eq '%s'", dbc.name),
 		},
+		GeneralParams: dbc.Parameters.GeneralParams,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/broker/get_broker.go
+++ b/internal/cmd/broker/get_broker.go
@@ -47,6 +47,7 @@ func (gb *GetBrokerCmd) Run() error {
 		FieldQuery: []string{
 			fmt.Sprintf("name eq '%s'", gb.name),
 		},
+		GeneralParams: gb.Parameters.GeneralParams,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/broker/update_broker.go
+++ b/internal/cmd/broker/update_broker.go
@@ -67,6 +67,7 @@ func (ubc *UpdateBrokerCmd) Run() error {
 		FieldQuery: []string{
 			fmt.Sprintf("name eq '%s'", ubc.name),
 		},
+		GeneralParams: ubc.Parameters.GeneralParams,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/instance/deprovision.go
+++ b/internal/cmd/instance/deprovision.go
@@ -61,6 +61,7 @@ func (dbc *DeprovisionCmd) Run() error {
 			FieldQuery: []string{
 				fmt.Sprintf("name eq '%s'", dbc.name),
 			},
+			GeneralParams: dbc.Parameters.GeneralParams,
 		})
 		if err != nil {
 			return err

--- a/internal/cmd/instance/get_instance.go
+++ b/internal/cmd/instance/get_instance.go
@@ -32,8 +32,8 @@ import (
 type GetInstanceCmd struct {
 	*cmd.Context
 
-	instanceName string
-	outputFormat output.Format
+	instanceName   string
+	outputFormat   output.Format
 	instanceParams *bool
 }
 
@@ -48,6 +48,7 @@ func (gb *GetInstanceCmd) Run() error {
 		FieldQuery: []string{
 			fmt.Sprintf("name eq '%s'", gb.instanceName),
 		},
+		GeneralParams: gb.Parameters.GeneralParams,
 	})
 	if err != nil {
 		return err
@@ -85,7 +86,6 @@ func (gb *GetInstanceCmd) Run() error {
 
 func (gb *GetInstanceCmd) printParameters(instances *types.ServiceInstances) error {
 
-
 	for _, instance := range instances.ServiceInstances {
 		parameters, err := gb.Client.GetInstanceParameters(instance.ID, &gb.Parameters)
 		if err != nil {
@@ -101,8 +101,8 @@ func (gb *GetInstanceCmd) printParameters(instances *types.ServiceInstances) err
 			output.PrintMessage(gb.Output, "No configuration parameters are set for service instance id: %s\n\n", instance.ID)
 			continue
 		}
-		output.PrintMessage(gb.Output, "Showing configuration parameters for service instance id: %s \n", instance.ID )
-		output.PrintMessage(gb.Output, "The parameters: \n"  )
+		output.PrintMessage(gb.Output, "Showing configuration parameters for service instance id: %s \n", instance.ID)
+		output.PrintMessage(gb.Output, "The parameters: \n")
 
 		output.PrintMessage(gb.Output, "%s \n\n", output.PrintParameters(parameters))
 	}

--- a/internal/cmd/instance/provision.go
+++ b/internal/cmd/instance/provision.go
@@ -84,6 +84,7 @@ func (pi *ProvisionCmd) Run() error {
 		FieldQuery: []string{
 			fmt.Sprintf("name eq '%s'", pi.offeringName),
 		},
+		GeneralParams: pi.Parameters.GeneralParams,
 	})
 	if err != nil {
 		return err
@@ -103,6 +104,7 @@ func (pi *ProvisionCmd) Run() error {
 			FieldQuery: []string{
 				fmt.Sprintf("name eq '%s'", pi.brokerName),
 			},
+			GeneralParams: pi.Parameters.GeneralParams,
 		})
 		if err != nil {
 			return err
@@ -123,6 +125,7 @@ func (pi *ProvisionCmd) Run() error {
 			fmt.Sprintf("name eq '%s'", pi.planName),
 			fmt.Sprintf("service_offering_id eq '%s'", pi.instance.ServiceID),
 		},
+		GeneralParams: pi.Parameters.GeneralParams,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/instance/transfer.go
+++ b/internal/cmd/instance/transfer.go
@@ -96,6 +96,7 @@ func (trc *TransferCmd) Run() error {
 				fmt.Sprintf("name eq '%s'", trc.instanceName),
 				fmt.Sprintf("platform_id eq '%s'", trc.fromPlatformID),
 			},
+			GeneralParams: trc.Parameters.GeneralParams,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
When passing parameters with `--param` those parameters should be sent with every request to service-manager. In some of the flows requests made to fetch data before the operation ignored them, this change is adding them there as well.