### PR TITLE
propagate params to SM in binding commands

### DIFF
--- a/internal/cmd/binding/get_binding.go
+++ b/internal/cmd/binding/get_binding.go
@@ -71,7 +71,7 @@ func (gb *GetBindingCmd) Run() error {
 			}
 			return err
 		}
-		instance, err := gb.Client.GetInstanceByID(bd.ServiceInstanceID, &query.Parameters{})
+		instance, err := gb.Client.GetInstanceByID(bd.ServiceInstanceID, &gb.Parameters)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/binding/list_bindings.go
+++ b/internal/cmd/binding/list_bindings.go
@@ -19,7 +19,6 @@ package binding
 import (
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 	"github.com/Peripli/service-manager-cli/internal/output"
-	"github.com/Peripli/service-manager-cli/pkg/query"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +42,7 @@ func (li *ListBindingsCmd) Run() error {
 	}
 
 	for i := range bindings.ServiceBindings {
-		instance, err := li.Client.GetInstanceByID(bindings.ServiceBindings[i].ServiceInstanceID, &query.Parameters{})
+		instance, err := li.Client.GetInstanceByID(bindings.ServiceBindings[i].ServiceInstanceID, &li.Parameters)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix 2 binding commands that I missed in https://github.com/Peripli/service-manager-cli/pull/86