### PR TITLE
share/unshare commands

### DIFF
--- a/internal/cmd/instance/transfer.go
+++ b/internal/cmd/instance/transfer.go
@@ -61,7 +61,7 @@ func (trc *TransferCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 	}
 
 	result.Flags().BoolVarP(&trc.force, "force", "f", false, "Force transfer without confirmation")
-	result.Flags().StringVarP(&trc.instanceID, "id", "", "", "Id of the instance. Required in case when there are instances with same name")
+	result.Flags().StringVarP(&trc.instanceID, "id", "", "", cmd.INSTANCE_ID_DESCRIPTION)
 	result.Flags().StringVarP(&trc.fromPlatformID, "from", "", "", "ID of the platform from which you want to move the instance")
 	result.Flags().StringVarP(&trc.toPlatformID, "to", "", "", "ID of the platform to which you want to move the instance")
 	cmd.AddFormatFlag(result.Flags())
@@ -102,11 +102,11 @@ func (trc *TransferCmd) Run() error {
 			return err
 		}
 		if len(instances.ServiceInstances) == 0 {
-			return fmt.Errorf("no instances found with name %s", trc.instanceName)
+			return fmt.Errorf(cmd.NO_INSTANCES_FOUND, trc.instanceName)
 		}
 
 		if len(instances.ServiceInstances) > 1 {
-			return fmt.Errorf("more than 1 instance found with name %s. Use --id flag to specify one", trc.instanceName)
+			return fmt.Errorf(cmd.FOUND_TOO_MANY_INSTANCES, trc.instanceName, "transfer")
 		}
 
 		trc.instanceID = instances.ServiceInstances[0].ID

--- a/internal/cmd/instance/transfer_test.go
+++ b/internal/cmd/instance/transfer_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-
+	"fmt"
 	"github.com/Peripli/service-manager-cli/internal/cmd"
 	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
 	"github.com/Peripli/service-manager-cli/pkg/types"
@@ -120,7 +120,7 @@ var _ = Describe("Transfer Command test", func() {
 			Context("when no instance id is provided", func() {
 				It("should require flag for instance id", func() {
 					err := invalidTransferCommandExecution("instance-name", "--from", "from_platform", "--to", "to_platform")
-					Expect(err.Error()).To(Equal("more than 1 instance found with name instance-name. Use --id flag to specify one"))
+					Expect(err.Error()).To(Equal(fmt.Sprintf(cmd.FOUND_TOO_MANY_INSTANCES,"instance-name","transfer")))
 				})
 			})
 
@@ -141,7 +141,8 @@ var _ = Describe("Transfer Command test", func() {
 
 			It("should fail to transfer", func() {
 				err := invalidTransferCommandExecution("no-instance", "--from", "from_platform", "--to", "to_platform")
-				Expect(err.Error()).To(Equal("no instances found with name no-instance"))
+				message:=fmt.Sprintf(cmd.NO_INSTANCES_FOUND,"no-instance")
+				Expect(err.Error()).To(Equal(message))
 			})
 		})
 

--- a/internal/cmd/instance/update_instance.go
+++ b/internal/cmd/instance/update_instance.go
@@ -29,16 +29,15 @@ import (
 
 type UpdateCmd struct {
 	*cmd.Context
-	instance        types.ServiceInstance
-	instanceName    string
-	planName        string
-	parametersJSON  string
-	outputFormat    output.Format
+	instance       types.ServiceInstance
+	instanceName   string
+	planName       string
+	parametersJSON string
+	outputFormat   output.Format
 }
 
-
 func NewUpdateInstanceCmd(context *cmd.Context) *UpdateCmd {
-	return &UpdateCmd{Context: context,instance: types.ServiceInstance{}}
+	return &UpdateCmd{Context: context, instance: types.ServiceInstance{}}
 }
 
 // Prepare returns cobra command
@@ -81,11 +80,12 @@ func (uc *UpdateCmd) Run() error {
 			return err
 		}
 		if len(instances.ServiceInstances) == 0 {
-			return fmt.Errorf("no instances found with name %s", uc.instanceName)
+			return fmt.Errorf(cmd.NO_INSTANCES_FOUND, uc.instanceName)
 		}
 
 		if len(instances.ServiceInstances) > 1 {
-			return fmt.Errorf("more than 1 instance found with name %s. Use --id flag to specify one", uc.instanceName)
+			return fmt.Errorf(cmd.FOUND_TOO_MANY_INSTANCES, uc.instanceName, "update")
+
 		}
 		instanceBeforeUpdate = &instances.ServiceInstances[0]
 

--- a/internal/cmd/instance/update_instance_test.go
+++ b/internal/cmd/instance/update_instance_test.go
@@ -171,7 +171,7 @@ var _ = Describe("update instance command test", func() {
 			Context("by name", func() {
 				It("should return an error", func() {
 					err := invalidUpdateInstanceCommandExecution("instance-name", "--new-name", "new name")
-					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no instances found with name %s", "instance-name")))
+					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.NO_INSTANCES_FOUND, "instance-name")))
 				})
 
 			})
@@ -203,7 +203,7 @@ var _ = Describe("update instance command test", func() {
 			})
 			It("should return an error", func() {
 				err := invalidUpdateInstanceCommandExecution("instance-name", "--new-name", "new name")
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("more than 1 instance found with name %s", "instance-name")))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.FOUND_TOO_MANY_INSTANCES, "instance-name","update")))
 			})
 
 		})

--- a/internal/cmd/instance/update_sharing_instance.go
+++ b/internal/cmd/instance/update_sharing_instance.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package instance
+
+import (
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/internal/output"
+	"github.com/Peripli/service-manager-cli/pkg/query"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type UpdateSharingCmd struct {
+	*cmd.Context
+	instanceName string
+	instanceID   string
+	outputFormat output.Format
+	share        bool
+}
+
+// NewUpdateSharingCmd returns new share/unshare instance command with context
+func NewUpdateSharingCmd(context *cmd.Context, share bool) *UpdateSharingCmd {
+	return &UpdateSharingCmd{Context: context, share: share}
+}
+
+// Prepare returns cobra command
+func (shc *UpdateSharingCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
+	result := &cobra.Command{
+		PreRunE: prepare(shc, shc.Context),
+		RunE:    cmd.RunE(shc),
+	}
+	if shc.share {
+		result.Use = "share-instance [name] --id service-instance-id "
+		result.Short = "Share a service instance"
+		result.Long = `Share a service instance so that it can be consumed from various platforms in your subaccount.
+Instance can be shared only if it was created with the plan that supports instance sharing. For more information, see the documentation of the service whose instance you want to share.`
+	} else {
+		result.Use = "unshare-instance [name] --id service-instance-id "
+		result.Short = "Unshare a service instance"
+		result.Long = `Unshare a service instance to disable its consumption from any but the original platform in which it was created in your subaccount. If an instance you want to unshare has references, an error is returned`
+	}
+	result.Flags().StringVarP(&shc.instanceID, "id", "", "", "Id of the instance. Required in case when there are instances with same name")
+	cmd.AddFormatFlag(result.Flags())
+	cmd.AddModeFlag(result.Flags(), "async")
+
+	return result
+}
+
+// Validate validates command's arguments
+func (shc *UpdateSharingCmd) Validate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("service instance name is required")
+	}
+	shc.instanceName = args[0]
+	return nil
+}
+
+// Run runs the command's logic
+func (shc *UpdateSharingCmd) Run() error {
+	if shc.instanceID == "" {
+		instances, err := shc.Client.ListInstances(&query.Parameters{
+			FieldQuery: []string{
+				fmt.Sprintf("name eq '%s'", shc.instanceName),
+			},
+			GeneralParams: shc.Parameters.GeneralParams,
+		})
+		if err != nil {
+			return err
+		}
+		if len(instances.ServiceInstances) == 0 {
+			return fmt.Errorf("no instances found with name %s", shc.instanceName)
+		}
+
+		if len(instances.ServiceInstances) > 1 {
+			return fmt.Errorf("more than 1 instance found with name %s. Use --id flag to specify one", shc.instanceName)
+		}
+
+		shc.instanceID = instances.ServiceInstances[0].ID
+	}
+	resultInstance, location, err := shc.Client.UpdateInstance(shc.instanceID, &types.ServiceInstance{
+		Shared: shc.share,
+	}, nil)
+	var message = ""
+	if err != nil {
+		if shc.share {
+			message = "Could not share service instance. Reason: "
+		} else {
+			message = "Could not unshare service instance. Reason: "
+		}
+		output.PrintMessage(shc.Output, message)
+		return err
+	}
+
+	if len(location) != 0 {
+		if shc.share {
+			message = fmt.Sprintf("Service Instance %s successfully scheduled for sharing. To see status of the operation use:\n", shc.instanceName)
+
+		} else {
+			message = fmt.Sprintf("Service Instance %s successfully scheduled for unsharing. To see status of the operation use:\n", shc.instanceName)
+		}
+		cmd.CommonHandleAsyncExecution(shc.Context, location, message)
+		return nil
+	}
+	output.PrintServiceManagerObject(shc.Output, shc.outputFormat, resultInstance)
+	output.Println(shc.Output)
+	return nil
+}
+
+// SetOutputFormat set output format
+func (shc *UpdateSharingCmd) SetOutputFormat(format output.Format) {
+	shc.outputFormat = format
+}

--- a/internal/cmd/instance/update_sharing_instance.go
+++ b/internal/cmd/instance/update_sharing_instance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Peripli/service-manager-cli/internal/output"
 	"github.com/Peripli/service-manager-cli/pkg/query"
 	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/Peripli/service-manager/pkg/web"
 
 	"fmt"
 
@@ -52,7 +53,7 @@ func (shc *UpdateSharingCmd) Prepare(prepare cmd.PrepareFunc) *cobra.Command {
 		result.Use = "share-instance [name] --id service-instance-id "
 		result.Short = "Share a service instance"
 		result.Long = `Share a service instance so that it can be consumed from various platforms in your subaccount.
-Instance can be shared only if it was created with the plan that supports instance sharing. For more information, see the documentation of the service whose instance you want to share.`
+Instance can be shared only if it was created with the plan that supports instance sharing. For more information, see the documentation of the service whose instance you want to share. To check if the service instance was created with a shareable plan, use 'smctl list-plans'.`
 	} else {
 		shc.action = "unshare"
 		result.Use = "unshare-instance [name] --id service-instance-id "
@@ -95,12 +96,14 @@ func (shc *UpdateSharingCmd) Run() error {
 
 		shc.instanceID = instances.ServiceInstances[0].ID
 	}
+	shc.Parameters.GeneralParams = append(shc.Parameters.GeneralParams, fmt.Sprintf("%s=%s", web.QueryParamAsync, "false"))
 	resultInstance, _, err := shc.Client.UpdateInstance(shc.instanceID, &types.ServiceInstance{
 		Shared: shc.share,
-	}, nil)
-
+	}, &query.Parameters{
+		GeneralParams: shc.Parameters.GeneralParams,
+	})
 	if err != nil {
-		output.PrintMessage(shc.Output, fmt.Sprintf("Couldn't %s the service instance. Reason:", shc.action))
+		output.PrintMessage(shc.Output, fmt.Sprintf("Couldn't %s the service instance. ", shc.action))
 		return err
 	}
 

--- a/internal/cmd/instance/update_sharing_instance.go
+++ b/internal/cmd/instance/update_sharing_instance.go
@@ -97,8 +97,10 @@ func (shc *UpdateSharingCmd) Run() error {
 		shc.instanceID = instances.ServiceInstances[0].ID
 	}
 	shc.Parameters.GeneralParams = append(shc.Parameters.GeneralParams, fmt.Sprintf("%s=%s", web.QueryParamAsync, "false"))
+	shared:=new(bool)
+	*shared = shc.share
 	resultInstance, _, err := shc.Client.UpdateInstance(shc.instanceID, &types.ServiceInstance{
-		Shared: shc.share,
+		Shared: shared,
 	}, &query.Parameters{
 		GeneralParams: shc.Parameters.GeneralParams,
 	})

--- a/internal/cmd/instance/update_sharing_instance.go
+++ b/internal/cmd/instance/update_sharing_instance.go
@@ -61,8 +61,6 @@ Instance can be shared only if it was created with the plan that supports instan
 	}
 	result.Flags().StringVarP(&shc.instanceID, "id", "", "", cmd.INSTANCE_ID_DESCRIPTION)
 	cmd.AddFormatFlag(result.Flags())
-	cmd.AddModeFlag(result.Flags(), "async")
-
 	return result
 }
 
@@ -97,25 +95,15 @@ func (shc *UpdateSharingCmd) Run() error {
 
 		shc.instanceID = instances.ServiceInstances[0].ID
 	}
-	resultInstance, location, err := shc.Client.UpdateInstance(shc.instanceID, &types.ServiceInstance{
+	resultInstance, _, err := shc.Client.UpdateInstance(shc.instanceID, &types.ServiceInstance{
 		Shared: shc.share,
 	}, nil)
-	var message = ""
+
 	if err != nil {
-		output.PrintMessage(shc.Output, fmt.Sprintf("Couldn't %s the service instance. Reason:",shc.action))
+		output.PrintMessage(shc.Output, fmt.Sprintf("Couldn't %s the service instance. Reason:", shc.action))
 		return err
 	}
 
-	if len(location) != 0 {
-		if shc.share {
-			message = fmt.Sprintf("Service instance \"%s\" successfully scheduled for sharing. To see the status of the operation, use: \n", shc.instanceName)
-
-		} else {
-			message = fmt.Sprintf("Service instance \"%s\" successfully scheduled for unsharing. To see the status of the operation, use: \n", shc.instanceName)
-		}
-		cmd.CommonHandleAsyncExecution(shc.Context, location, message)
-		return nil
-	}
 	output.PrintServiceManagerObject(shc.Output, shc.outputFormat, resultInstance)
 	output.Println(shc.Output)
 	return nil

--- a/internal/cmd/instance/update_sharing_instance_test.go
+++ b/internal/cmd/instance/update_sharing_instance_test.go
@@ -60,8 +60,6 @@ var _ = Describe("Update sharing instance command test", func() {
 		return piCmd
 	}
 
-
-
 	invalidUpdateSharingCommandExecution := func(args ...string) error {
 		shCmd := command.Prepare(cmd.SmPrepare)
 		shCmd.SetArgs(args)
@@ -126,17 +124,29 @@ var _ = Describe("Update sharing instance command test", func() {
 
 				})
 
-				Context("when service instance not found", func() {
+				When("invalid flag", func() {
+					It("should return an error", func() {
+						err := invalidUpdateSharingCommandExecution("instance name", "--fl", "fff")
+						Expect(err).Should(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("unknown flag: --fl"))
+					})
+				})
+				When("async is used", func() {
+					It("should return an error", func() {
+						err := invalidUpdateSharingCommandExecution("instance name", "--mode", "async")
+						Expect(err).Should(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("unknown flag: --mode"))
+					})
+				})
+
+				When("service instance not found", func() {
 					BeforeEach(func() {
 						instances = &types.ServiceInstances{}
 					})
 
-					Context("by name", func() {
-						It("should return an error", func() {
-							err := invalidUpdateSharingCommandExecution("instance-name")
-							Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.NO_INSTANCES_FOUND, "instance-name")))
-						})
-
+					It("should return an error", func() {
+						err := invalidUpdateSharingCommandExecution("instance-name")
+						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.NO_INSTANCES_FOUND, "instance-name")))
 					})
 
 				})
@@ -155,7 +165,7 @@ var _ = Describe("Update sharing instance command test", func() {
 					})
 					It("should return an error", func() {
 						err := invalidUpdateSharingCommandExecution("instance-name")
-						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.FOUND_TOO_MANY_INSTANCES, "instance-name",test.commandName)))
+						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.FOUND_TOO_MANY_INSTANCES, "instance-name", test.commandName)))
 					})
 
 				})

--- a/internal/cmd/instance/update_sharing_instance_test.go
+++ b/internal/cmd/instance/update_sharing_instance_test.go
@@ -78,10 +78,10 @@ var _ = Describe("Update sharing instance command test", func() {
 	tests := []testCase{
 		testCase{true, "share",
 			"successfully scheduled for sharing",
-			"Could not share service instance"},
+			"Couldn't share the service instance. Reason:"},
 		testCase{false, "unshare",
 			"successfully scheduled for unsharing",
-			"Could not unshare service instance"},
+			"Couldn't unshare the service instance. Reason:"},
 	}
 	for _, test := range tests {
 		Describe(fmt.Sprintf("%s instance", test.title), func() {
@@ -161,7 +161,7 @@ var _ = Describe("Update sharing instance command test", func() {
 					Context("by name", func() {
 						It("should return an error", func() {
 							err := invalidUpdateSharingCommandExecution("instance-name")
-							Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no instances found with name %s", "instance-name")))
+							Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.NO_INSTANCES_FOUND, "instance-name")))
 						})
 
 					})
@@ -182,7 +182,7 @@ var _ = Describe("Update sharing instance command test", func() {
 					})
 					It("should return an error", func() {
 						err := invalidUpdateSharingCommandExecution("instance-name")
-						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("more than 1 instance found with name %s", "instance-name")))
+						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.FOUND_TOO_MANY_INSTANCES, "instance-name",test.title)))
 					})
 
 				})

--- a/internal/cmd/instance/update_sharing_instance_test.go
+++ b/internal/cmd/instance/update_sharing_instance_test.go
@@ -68,17 +68,15 @@ var _ = Describe("Update sharing instance command test", func() {
 		return shCmd.Execute()
 	}
 	type testCase struct {
-		share        bool
-		title        string
-		errorMessage string
+		share       bool
+		commandName string
 	}
 	tests := []testCase{
-		testCase{true, "share",
-			"Couldn't share the service instance. Reason:"},
-		testCase{false, "unshare", "Couldn't unshare the service instance. Reason:"},
+		testCase{true, "share"},
+		testCase{false, "unshare"},
 	}
 	for _, test := range tests {
-		Describe(fmt.Sprintf("%s instance", test.title), func() {
+		Describe(fmt.Sprintf("%s instance", test.commandName), func() {
 			BeforeEach(func() {
 				buffer = &bytes.Buffer{}
 				client = &smclientfakes.FakeClient{}
@@ -157,7 +155,7 @@ var _ = Describe("Update sharing instance command test", func() {
 					})
 					It("should return an error", func() {
 						err := invalidUpdateSharingCommandExecution("instance-name")
-						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.FOUND_TOO_MANY_INSTANCES, "instance-name",test.title)))
+						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(cmd.FOUND_TOO_MANY_INSTANCES, "instance-name",test.commandName)))
 					})
 
 				})
@@ -178,6 +176,8 @@ var _ = Describe("Update sharing instance command test", func() {
 						err := invalidUpdateSharingCommandExecution("instance-name")
 						Expect(err).Should(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("HTTP response error"))
+						Expect(buffer.String()).To(ContainSubstring(fmt.Sprintf("Couldn't %s the service instance. ", test.commandName)))
+
 					})
 
 				})

--- a/internal/cmd/instance/update_sharing_instance_test.go
+++ b/internal/cmd/instance/update_sharing_instance_test.go
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package instance
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/Peripli/service-manager-cli/internal/cmd"
+	"github.com/Peripli/service-manager-cli/pkg/smclient/smclientfakes"
+	"github.com/Peripli/service-manager-cli/pkg/types"
+	"github.com/Peripli/service-manager/pkg/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"net/http"
+)
+
+var _ = Describe("Update sharing instance command test", func() {
+	var client *smclientfakes.FakeClient
+	var command *UpdateSharingCmd
+	var buffer *bytes.Buffer
+	var instance *types.ServiceInstance
+	var instances *types.ServiceInstances
+	validAsyncUpdateSharingExecution := func(location string, args ...string) *cobra.Command {
+		instance = &types.ServiceInstance{
+			Name: args[0],
+		}
+		for i, arg := range args {
+			if arg == "--id" {
+				instance.ID = args[i+1]
+			}
+		}
+		operation := &types.Operation{
+			State: "in progress",
+		}
+
+		client.StatusReturns(operation, nil)
+		client.ListInstancesReturns(&types.ServiceInstances{ServiceInstances: []types.ServiceInstance{*instance}}, nil)
+		client.UpdateInstanceReturns(instance, location, nil)
+		piCmd := command.Prepare(cmd.SmPrepare)
+		piCmd.SetArgs(args)
+		Expect(piCmd.Execute()).ToNot(HaveOccurred())
+		return piCmd
+	}
+
+	validSyncUpdateSharingExect := func(args ...string) *cobra.Command {
+		return validAsyncUpdateSharingExecution("", append(args, "--mode", "sync")...)
+	}
+
+	invalidUpdateSharingCommandExecution := func(args ...string) error {
+		shCmd := command.Prepare(cmd.SmPrepare)
+		shCmd.SetArgs(args)
+		return shCmd.Execute()
+	}
+	type testCase struct {
+		share        bool
+		title        string
+		asyncMessage string
+		errorMessage string
+	}
+	tests := []testCase{
+		testCase{true, "share",
+			"successfully scheduled for sharing",
+			"Could not share service instance"},
+		testCase{false, "unshare",
+			"successfully scheduled for unsharing",
+			"Could not unshare service instance"},
+	}
+	for _, test := range tests {
+		Describe(fmt.Sprintf("%s instance", test.title), func() {
+			BeforeEach(func() {
+				buffer = &bytes.Buffer{}
+				client = &smclientfakes.FakeClient{}
+				context := &cmd.Context{Output: buffer, Client: client}
+				command = NewUpdateSharingCmd(context, test.share)
+			})
+			Context("valid async", func() {
+				It("should print status command", func() {
+					validAsyncUpdateSharingExecution("location",
+						"myinstancename")
+					Expect(buffer.String()).To(ContainSubstring(`smctl status location`))
+					Expect(buffer.String()).To(ContainSubstring(test.asyncMessage))
+				})
+				Context("with id", func() {
+					It("should print status command", func() {
+						validAsyncUpdateSharingExecution("location",
+							"myinstancename", "--id", "serviceinstanceid")
+						Expect(buffer.String()).To(ContainSubstring(`smctl status location`))
+						Expect(buffer.String()).To(ContainSubstring(test.asyncMessage))
+					})
+				})
+
+
+			})
+
+
+			Context("valid sync", func() {
+				Context("with name", func() {
+					It("should print object", func() {
+						validSyncUpdateSharingExect("myinstancename")
+						tableOutputExpected := instance.TableData().String()
+						Expect(buffer.String()).To(ContainSubstring(tableOutputExpected))
+					})
+
+				})
+				Context("with id", func() {
+					It("should print object", func() {
+						validSyncUpdateSharingExect("myinstancename", "--id", "serviceinstanceid")
+						tableOutputExpected := instance.TableData().String()
+						Expect(buffer.String()).To(ContainSubstring(tableOutputExpected))
+					})
+				})
+
+				Context("With json output flag", func() {
+					It("should be printed in json output format", func() {
+						validSyncUpdateSharingExect("instance-name", "--output", "json")
+						jsonByte, _ := json.MarshalIndent(instance, "", "  ")
+						jsonOutputExpected := string(jsonByte) + "\n"
+						Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
+					})
+				})
+
+				Context("With yaml output flag", func() {
+					It("should be printed in yaml output format", func() {
+						validSyncUpdateSharingExect("instance-name", "--output", "yaml")
+						yamlByte, _ := yaml.Marshal(instance)
+						yamlOutputExpected := string(yamlByte) + "\n"
+						Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))
+					})
+				})
+			})
+
+			Context("invalid execution", func() {
+				JustBeforeEach(func() {
+					client.ListInstancesReturns(instances, nil)
+
+				})
+
+				Context("when service instance not found", func() {
+					BeforeEach(func() {
+						instances = &types.ServiceInstances{}
+					})
+
+					Context("by name", func() {
+						It("should return an error", func() {
+							err := invalidUpdateSharingCommandExecution("instance-name")
+							Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no instances found with name %s", "instance-name")))
+						})
+
+					})
+
+				})
+				Context("when more than once instance found", func() {
+					BeforeEach(func() {
+						client.ListInstancesReturnsOnCall(0, &types.ServiceInstances{
+							ServiceInstances: []types.ServiceInstance{
+								types.ServiceInstance{
+									Name: "instance-name",
+								},
+								types.ServiceInstance{
+									Name: "instance-name",
+								},
+							},
+						}, nil)
+					})
+					It("should return an error", func() {
+						err := invalidUpdateSharingCommandExecution("instance-name")
+						Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("more than 1 instance found with name %s", "instance-name")))
+					})
+
+				})
+				Context("backend error", func() {
+					BeforeEach(func() {
+						client.ListInstancesReturnsOnCall(0, &types.ServiceInstances{
+							ServiceInstances: []types.ServiceInstance{
+								types.ServiceInstance{
+									Name: "instance-name",
+								},
+							},
+						}, nil)
+						body := ioutil.NopCloser(bytes.NewReader([]byte("HTTP response error")))
+						expectedError := util.HandleResponseError(&http.Response{Body: body})
+						client.UpdateInstanceReturns(nil, "", expectedError)
+					})
+					It("should return error's description", func() {
+						err := invalidUpdateSharingCommandExecution("instance-name")
+						Expect(err).Should(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("HTTP response error"))
+					})
+
+				})
+
+				Context("With invalid output format", func() {
+					It("should return error", func() {
+						invFormat := "invalid-format"
+						err := invalidUpdateSharingCommandExecution("instance name", "--output", invFormat)
+						Expect(err).Should(HaveOccurred())
+						Expect(err.Error()).To(Equal("unknown output: " + invFormat))
+					})
+				})
+
+			})
+
+		})
+
+	}
+})

--- a/internal/cmd/instance/update_sharing_instance_test.go
+++ b/internal/cmd/instance/update_sharing_instance_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Update sharing instance command test", func() {
 	var buffer *bytes.Buffer
 	var instance *types.ServiceInstance
 	var instances *types.ServiceInstances
-	validAsyncUpdateSharingExecution := func(location string, args ...string) *cobra.Command {
+	validUpdateSharingExecution := func(args ...string) *cobra.Command {
 		instance = &types.ServiceInstance{
 			Name: args[0],
 		}
@@ -53,16 +53,14 @@ var _ = Describe("Update sharing instance command test", func() {
 
 		client.StatusReturns(operation, nil)
 		client.ListInstancesReturns(&types.ServiceInstances{ServiceInstances: []types.ServiceInstance{*instance}}, nil)
-		client.UpdateInstanceReturns(instance, location, nil)
+		client.UpdateInstanceReturns(instance, "", nil)
 		piCmd := command.Prepare(cmd.SmPrepare)
 		piCmd.SetArgs(args)
 		Expect(piCmd.Execute()).ToNot(HaveOccurred())
 		return piCmd
 	}
 
-	validSyncUpdateSharingExect := func(args ...string) *cobra.Command {
-		return validAsyncUpdateSharingExecution("", append(args, "--mode", "sync")...)
-	}
+
 
 	invalidUpdateSharingCommandExecution := func(args ...string) error {
 		shCmd := command.Prepare(cmd.SmPrepare)
@@ -91,7 +89,7 @@ var _ = Describe("Update sharing instance command test", func() {
 			Context("valid sync", func() {
 				Context("with name", func() {
 					It("should print object", func() {
-						validSyncUpdateSharingExect("myinstancename")
+						validUpdateSharingExecution("myinstancename")
 						tableOutputExpected := instance.TableData().String()
 						Expect(buffer.String()).To(ContainSubstring(tableOutputExpected))
 					})
@@ -99,7 +97,7 @@ var _ = Describe("Update sharing instance command test", func() {
 				})
 				Context("with id", func() {
 					It("should print object", func() {
-						validSyncUpdateSharingExect("myinstancename", "--id", "serviceinstanceid")
+						validUpdateSharingExecution("myinstancename", "--id", "serviceinstanceid")
 						tableOutputExpected := instance.TableData().String()
 						Expect(buffer.String()).To(ContainSubstring(tableOutputExpected))
 					})
@@ -107,7 +105,7 @@ var _ = Describe("Update sharing instance command test", func() {
 
 				Context("with json output flag", func() {
 					It("should be printed in json output format", func() {
-						validSyncUpdateSharingExect("instance-name", "--output", "json")
+						validUpdateSharingExecution("instance-name", "--output", "json")
 						jsonByte, _ := json.MarshalIndent(instance, "", "  ")
 						jsonOutputExpected := string(jsonByte) + "\n"
 						Expect(buffer.String()).To(ContainSubstring(jsonOutputExpected))
@@ -116,7 +114,7 @@ var _ = Describe("Update sharing instance command test", func() {
 
 				Context("with yaml output flag", func() {
 					It("should be printed in yaml output format", func() {
-						validSyncUpdateSharingExect("instance-name", "--output", "yaml")
+						validUpdateSharingExecution("instance-name", "--output", "yaml")
 						yamlByte, _ := yaml.Marshal(instance)
 						yamlOutputExpected := string(yamlByte) + "\n"
 						Expect(buffer.String()).To(ContainSubstring(yamlOutputExpected))

--- a/internal/cmd/instance/update_sharing_instance_test.go
+++ b/internal/cmd/instance/update_sharing_instance_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Update sharing instance command test", func() {
 					})
 				})
 
-				Context("With json output flag", func() {
+				Context("with json output flag", func() {
 					It("should be printed in json output format", func() {
 						validSyncUpdateSharingExect("instance-name", "--output", "json")
 						jsonByte, _ := json.MarshalIndent(instance, "", "  ")
@@ -137,7 +137,7 @@ var _ = Describe("Update sharing instance command test", func() {
 					})
 				})
 
-				Context("With yaml output flag", func() {
+				Context("with yaml output flag", func() {
 					It("should be printed in yaml output format", func() {
 						validSyncUpdateSharingExect("instance-name", "--output", "yaml")
 						yamlByte, _ := yaml.Marshal(instance)
@@ -207,7 +207,7 @@ var _ = Describe("Update sharing instance command test", func() {
 
 				})
 
-				Context("With invalid output format", func() {
+				Context("with invalid output format", func() {
 					It("should return error", func() {
 						invFormat := "invalid-format"
 						err := invalidUpdateSharingCommandExecution("instance name", "--output", invFormat)

--- a/internal/cmd/instance/update_sharing_instance_test.go
+++ b/internal/cmd/instance/update_sharing_instance_test.go
@@ -72,16 +72,12 @@ var _ = Describe("Update sharing instance command test", func() {
 	type testCase struct {
 		share        bool
 		title        string
-		asyncMessage string
 		errorMessage string
 	}
 	tests := []testCase{
 		testCase{true, "share",
-			"successfully scheduled for sharing",
 			"Couldn't share the service instance. Reason:"},
-		testCase{false, "unshare",
-			"successfully scheduled for unsharing",
-			"Couldn't unshare the service instance. Reason:"},
+		testCase{false, "unshare", "Couldn't unshare the service instance. Reason:"},
 	}
 	for _, test := range tests {
 		Describe(fmt.Sprintf("%s instance", test.title), func() {
@@ -91,25 +87,6 @@ var _ = Describe("Update sharing instance command test", func() {
 				context := &cmd.Context{Output: buffer, Client: client}
 				command = NewUpdateSharingCmd(context, test.share)
 			})
-			Context("valid async", func() {
-				It("should print status command", func() {
-					validAsyncUpdateSharingExecution("location",
-						"myinstancename")
-					Expect(buffer.String()).To(ContainSubstring(`smctl status location`))
-					Expect(buffer.String()).To(ContainSubstring(test.asyncMessage))
-				})
-				Context("with id", func() {
-					It("should print status command", func() {
-						validAsyncUpdateSharingExecution("location",
-							"myinstancename", "--id", "serviceinstanceid")
-						Expect(buffer.String()).To(ContainSubstring(`smctl status location`))
-						Expect(buffer.String()).To(ContainSubstring(test.asyncMessage))
-					})
-				})
-
-
-			})
-
 
 			Context("valid sync", func() {
 				Context("with name", func() {

--- a/internal/cmd/messages.go
+++ b/internal/cmd/messages.go
@@ -1,0 +1,5 @@
+package cmd
+
+const NO_INSTANCES_FOUND = "Couldn't find an instance with the name \"%s\"."
+const INSTANCE_ID_DESCRIPTION = "The instance ID. Required if there is more than one instance with the same name."
+const FOUND_TOO_MANY_INSTANCES = "Found more than one instance with the name \"%s\". Use the --id flag to specify which instance to %s."

--- a/main.go
+++ b/main.go
@@ -93,6 +93,9 @@ func main() {
 			instance.NewDeprovisionCmd(cmdContext, os.Stdin),
 			instance.NewTransferCmd(cmdContext, os.Stdin),
 			instance.NewUpdateInstanceCmd(cmdContext),
+			instance.NewUpdateSharingCmd(cmdContext,true),
+			instance.NewUpdateSharingCmd(cmdContext,false),
+
 
 		},
 		PrepareFn: cmd.SmPrepare,

--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -44,6 +44,7 @@ type ServiceInstance struct {
 
 	Ready  bool `json:"ready" yaml:"ready"`
 	Usable bool `json:"usable" yaml:"usable"`
+	Shared bool  `json:"shared,omitempty" yaml:"shared,omitempty"`
 
 	LastOperation *types.Operation `json:"last_operation,omitempty" yaml:"last_operation,omitempty"`
 }

--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -42,9 +42,9 @@ type ServiceInstance struct {
 	Context         json.RawMessage `json:"context,omitempty" yaml:"context,omitempty"`
 	PreviousValues  json.RawMessage `json:"-" yaml:"-"`
 
-	Ready         bool             `json:"ready" yaml:"ready"`
-	Usable        bool             `json:"usable" yaml:"usable"`
-	Shared        bool             `json:"shared,omitempty" yaml:"shared,omitempty"`
+	Ready         bool             `json:"ready,omitempty" yaml:"ready,omitempty"`
+	Usable        bool             `json:"usable,omitempty" yaml:"usable,omitempty"`
+	Shared        bool             `json:"shared" yaml:"shared"`
 	LastOperation *types.Operation `json:"last_operation,omitempty" yaml:"last_operation,omitempty"`
 }
 

--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -19,8 +19,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
-
 	"github.com/Peripli/service-manager/pkg/types"
 )
 
@@ -42,9 +40,9 @@ type ServiceInstance struct {
 	Context         json.RawMessage `json:"context,omitempty" yaml:"context,omitempty"`
 	PreviousValues  json.RawMessage `json:"-" yaml:"-"`
 
-	Ready         bool             `json:"ready,omitempty" yaml:"ready,omitempty"`
-	Usable        bool             `json:"usable,omitempty" yaml:"usable,omitempty"`
-	Shared        bool             `json:"shared" yaml:"shared"`
+	Ready         *bool             `json:"ready,omitempty" yaml:"ready,omitempty"`
+	Usable        *bool             `json:"usable,omitempty" yaml:"usable,omitempty"`
+	Shared        *bool             `json:"shared,omitempty" yaml:"shared,omitempty"`
 	LastOperation *types.Operation `json:"last_operation,omitempty" yaml:"last_operation,omitempty"`
 }
 
@@ -67,7 +65,7 @@ func (si *ServiceInstance) TableData() *TableData {
 	if si.LastOperation != nil {
 		lastState = formatLastOp(si.LastOperation)
 	}
-	row := []string{si.ID, si.Name, si.ServicePlanID, si.PlatformID, strconv.FormatBool(si.Shared), si.CreatedAt, si.UpdatedAt, strconv.FormatBool(si.Ready), strconv.FormatBool(si.Usable), formatLabels(si.Labels), lastState}
+	row := []string{si.ID, si.Name, si.ServicePlanID, si.PlatformID, formatNullableBool(si.Shared), si.CreatedAt, si.UpdatedAt, formatNullableBool(si.Ready), formatNullableBool(si.Usable), formatLabels(si.Labels), lastState}
 	result.Data = append(result.Data, row)
 
 	return result
@@ -111,7 +109,7 @@ func (si *ServiceInstances) TableData() *TableData {
 			lastState = formatLastOp(instance.LastOperation)
 			addLastOpColumn = true
 		}
-		row := []string{instance.ID, instance.Name, instance.ServicePlanID, instance.PlatformID, strconv.FormatBool(instance.Shared), instance.CreatedAt, instance.UpdatedAt, strconv.FormatBool(instance.Ready), strconv.FormatBool(instance.Usable), formatLabels(instance.Labels), lastState}
+		row := []string{instance.ID, instance.Name, instance.ServicePlanID, instance.PlatformID, formatNullableBool(instance.Shared), instance.CreatedAt, instance.UpdatedAt, formatNullableBool(instance.Ready), formatNullableBool(instance.Usable), formatLabels(instance.Labels), lastState}
 		result.Data = append(result.Data, row)
 	}
 

--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -42,10 +42,9 @@ type ServiceInstance struct {
 	Context         json.RawMessage `json:"context,omitempty" yaml:"context,omitempty"`
 	PreviousValues  json.RawMessage `json:"-" yaml:"-"`
 
-	Ready  bool `json:"ready" yaml:"ready"`
-	Usable bool `json:"usable" yaml:"usable"`
-	Shared bool  `json:"shared,omitempty" yaml:"shared,omitempty"`
-	Shareable bool `json:"shared,omitempty" yaml:"shareable,omitempty"`
+	Ready         bool             `json:"ready" yaml:"ready"`
+	Usable        bool             `json:"usable" yaml:"usable"`
+	Shared        bool             `json:"shared,omitempty" yaml:"shared,omitempty"`
 	LastOperation *types.Operation `json:"last_operation,omitempty" yaml:"last_operation,omitempty"`
 }
 
@@ -62,13 +61,13 @@ func (si *ServiceInstance) IsEmpty() bool {
 // TableData returns the data to populate a table
 func (si *ServiceInstance) TableData() *TableData {
 	result := &TableData{Vertical: true}
-	result.Headers = []string{"ID", "Name", "Service Plan ID", "Platform ID", "Created", "Updated", "Ready", "Usable", "Labels", "Last Op"}
+	result.Headers = []string{"ID", "Name", "Service Plan ID", "Platform ID", "Shared", "Created", "Updated", "Ready", "Usable", "Labels", "Last Op"}
 
 	lastState := "-"
 	if si.LastOperation != nil {
 		lastState = formatLastOp(si.LastOperation)
 	}
-	row := []string{si.ID, si.Name, si.ServicePlanID, si.PlatformID, si.CreatedAt, si.UpdatedAt, strconv.FormatBool(si.Ready), strconv.FormatBool(si.Usable), formatLabels(si.Labels), lastState}
+	row := []string{si.ID, si.Name, si.ServicePlanID, si.PlatformID, strconv.FormatBool(si.Shared), si.CreatedAt, si.UpdatedAt, strconv.FormatBool(si.Ready), strconv.FormatBool(si.Usable), formatLabels(si.Labels), lastState}
 	result.Data = append(result.Data, row)
 
 	return result
@@ -103,7 +102,7 @@ func (si *ServiceInstances) IsEmpty() bool {
 // TableData returns the data to populate a table
 func (si *ServiceInstances) TableData() *TableData {
 	result := &TableData{Vertical: si.Vertical}
-	result.Headers = []string{"ID", "Name", "Service Plan ID", "Platform ID", "Created", "Updated", "Ready", "Usable", "Labels"}
+	result.Headers = []string{"ID", "Name", "Service Plan ID", "Platform ID", "Shared", "Created", "Updated", "Ready", "Usable", "Labels"}
 
 	addLastOpColumn := false
 	for _, instance := range si.ServiceInstances {
@@ -112,7 +111,7 @@ func (si *ServiceInstances) TableData() *TableData {
 			lastState = formatLastOp(instance.LastOperation)
 			addLastOpColumn = true
 		}
-		row := []string{instance.ID, instance.Name, instance.ServicePlanID, instance.PlatformID, instance.CreatedAt, instance.UpdatedAt, strconv.FormatBool(instance.Ready), strconv.FormatBool(instance.Usable), formatLabels(instance.Labels), lastState}
+		row := []string{instance.ID, instance.Name, instance.ServicePlanID, instance.PlatformID, strconv.FormatBool(instance.Shared), instance.CreatedAt, instance.UpdatedAt, strconv.FormatBool(instance.Ready), strconv.FormatBool(instance.Usable), formatLabels(instance.Labels), lastState}
 		result.Data = append(result.Data, row)
 	}
 

--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -45,7 +45,7 @@ type ServiceInstance struct {
 	Ready  bool `json:"ready" yaml:"ready"`
 	Usable bool `json:"usable" yaml:"usable"`
 	Shared bool  `json:"shared,omitempty" yaml:"shared,omitempty"`
-
+	Shareable bool `json:"shared,omitempty" yaml:"shareable,omitempty"`
 	LastOperation *types.Operation `json:"last_operation,omitempty" yaml:"last_operation,omitempty"`
 }
 

--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/tidwall/gjson"
 	"strconv"
 )
 
@@ -132,12 +133,20 @@ func (sp *ServicePlans) IsEmpty() bool {
 // TableData returns the data to populate a table
 func (sp *ServicePlans) TableData() *TableData {
 	result := &TableData{}
-	result.Headers = []string{"ID", "Name", "Description", "Offering ID", "Ready", "Labels"}
+	result.Headers = []string{"ID", "Name", "Shareable", "Description", "Offering ID", "Ready", "Labels"}
 
 	for _, v := range sp.ServicePlans {
-		row := []string{v.ID, v.Name, v.Description, v.ServiceOfferingID, strconv.FormatBool(v.Ready), formatLabels(v.Labels)}
+		row := []string{v.ID, v.Name, strconv.FormatBool(v.ShareableProperty()), v.Description, v.ServiceOfferingID, strconv.FormatBool(v.Ready), formatLabels(v.Labels)}
 		result.Data = append(result.Data, row)
 	}
 
 	return result
+}
+
+func (sp *ServicePlan) ShareableProperty() bool {
+	if sp.Metadata == nil {
+		return false
+	}
+	return gjson.GetBytes(sp.Metadata, "supportInstanceSharing").Bool()
+
 }

--- a/pkg/types/tableData.go
+++ b/pkg/types/tableData.go
@@ -156,6 +156,12 @@ func max(arr ...int) int {
 	return tmp
 }
 
+func formatNullableBool(val *bool) string{
+	if val == nil {
+		return "false"
+	}
+	return fmt.Sprintf("%v", *val)
+}
 func formatLabels(labels types.Labels) string {
 	formattedLabels := make([]string, 0, len(labels))
 	for i, v := range labels {


### PR DESCRIPTION
New commands to mange sharing instance: 
* share-instance [name] --id service-instance-id
* unshare-instance [name] --id service-instance-id
Sharing a service instance allows to consume it from various platforms.