### PR TITLE
use const instance_sharing.SupportsInstanceSharingKey

### DIFF
--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/instance_sharing"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/tidwall/gjson"
 	"strconv"
@@ -147,6 +148,6 @@ func (sp *ServicePlan) ShareableProperty() bool {
 	if sp.Metadata == nil {
 		return false
 	}
-	return gjson.GetBytes(sp.Metadata, "supportInstanceSharing").Bool()
+	return gjson.GetBytes(sp.Metadata, instance_sharing.SupportsInstanceSharingKey).Bool()
 
 }


### PR DESCRIPTION
Use instance_sharing.SupportsInstanceSharingKey instead of a string of the key.