### PR TITLE
Added support for Linux ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
         include:
           - goos: darwin
             goarch: arm64
+          - goos: linux
+            goarch: arm64
     steps:
       - uses: actions/checkout@v2
       - name: Set APP_VERSION env


### PR DESCRIPTION
added support for Linux Arm64 arch.

# Pull Request Template

## Motivation
Proposing a solution for this
https://github.com/Peripli/service-manager-cli/issues/163

On Mac M1 machines, users run their development environment in docker containers. Building Docker containers on M1 machines result in using Linux on ARM. Running smctl amd64 binaries result in errors

## Approach
i added in the release yaml support to linux arm64



